### PR TITLE
fix(pi-webterm): session status stuck at running after new session

### DIFF
--- a/pi-webterm/ui/src/App.svelte
+++ b/pi-webterm/ui/src/App.svelte
@@ -27,7 +27,8 @@ import "./app.css";
 // ─── State ─────────────────────────────────────────────────────
 
 let terminalContainer: HTMLDivElement | undefined = $state();
-let baseUrl = $state(`ws://${window.location.host}`);
+const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+let baseUrl = $state(`${wsProtocol}//${window.location.host}`);
 let status = $state<ConnectionStatus>("disconnected");
 let _errorMsg = $state("");
 let _connected = $state(false);
@@ -314,6 +315,12 @@ function getSessionManager(): SessionConnectionManager {
     },
     onStatus: (s) => {
       console.log("Status:", s);
+      // Server confirms the PTY attachment — ensure connection state reflects this
+      if (s.connected) {
+        status = "connected";
+        _connected = true;
+        _errorMsg = "";
+      }
     },
   };
 

--- a/pi-webterm/ui/src/lib/ws.ts
+++ b/pi-webterm/ui/src/lib/ws.ts
@@ -90,8 +90,9 @@ export class WsClient {
       this.scheduleReconnect();
     };
 
-    this.ws.onerror = (_err: Event) => {
+    this.ws.onerror = (err: Event) => {
       this._status = "error";
+      this.options.onError?.(err);
     };
 
     this.ws.onmessage = (event: MessageEvent) => {


### PR DESCRIPTION
## Summary

- Fix WebSocket URL to auto-detect `ws://` vs `wss://` based on `window.location.protocol` — previously hardcoded to `ws://`, which blocks the connection when the page is served over HTTPS (mixed content).
- Propagate WebSocket `onerror` events to the parent handler via `options.onError` — the error was silently swallowed, preventing the UI from showing connection failure feedback.
- Update connection state (`status`, `_connected`) when the server confirms PTY attachment via the `{type:"status", connected:true}` message — the `onStatus` handler previously only logged the message.

## Testing

- Not run (no e2e/browser test harness configured for pi-webterm UI)
