### PR TITLE
fix(cr-diffview): focus herdr review tab after opening, matching tmux…

### DIFF
--- a/extensions/cr-diffview/herdr-multiplexer.ts
+++ b/extensions/cr-diffview/herdr-multiplexer.ts
@@ -162,6 +162,9 @@ export const createHerdrMultiplexer = (
 
       if (runResult.code !== 0) {
         await closeResolvedReviewView(created.tabId);
+      } else {
+        // Focus the review tab so the user sees Neovim, matching tmux new-window behavior.
+        await pi.exec("herdr", ["tab", "focus", created.tabId]);
       }
 
       return {

--- a/extensions/cr-diffview/index.test.ts
+++ b/extensions/cr-diffview/index.test.ts
@@ -374,6 +374,13 @@ describe("cr-diffview command", () => {
     expect(paneCommand).toContain("nvim --listen");
     expect(paneCommand).not.toContain("cd ");
 
+    // Verify the review tab is focused after creation, matching tmux new-window behavior.
+    expect(exec).toHaveBeenCalledWith("herdr", [
+      "tab",
+      "focus",
+      HERDR_REVIEW_TAB_ID,
+    ]);
+
     expect(notify).toHaveBeenCalledWith(
       "Opened CR diffview for main...HEAD",
       "info",


### PR DESCRIPTION
… behavior

- Call `herdr tab focus <reviewTabId>` after pane run succeeds in openReviewView so the user sees the Neovim diff tab immediately
- Add test assertion verifying that herdr tab focus is invoked for the review tab after creation