### PR TITLE
fix(plan-mode): break infinite post-run continuation loops on ESC and…

### DIFF
--- a/extensions/plan-mode/controller.ts
+++ b/extensions/plan-mode/controller.ts
@@ -85,10 +85,9 @@ const APPROVED_ARTIFACT_CHANGED_REVIEW_MESSAGE =
   "Plan Mode is waiting for an approved Plannotator plan/spec. The " +
   "approved artifact changed and must be reviewed again before " +
   "continuing approved execution.";
-const APPROVED_EXECUTION_ABORTED_REVIEW_MESSAGE =
-  "Plan Mode is waiting for an approved Plannotator plan/spec. The " +
-  "approved execution was aborted by the user and must be reviewed again " +
-  "before continuing.";
+// APPROVED_EXECUTION_ABORTED_REVIEW_MESSAGE removed - no longer used.
+// The abort path now uses ctx.ui.notify() instead of sendUserMessage()
+// to avoid restarting the agent (which caused an infinite retry loop).
 
 // ── Date helpers ──────────────────────────────────────────────
 
@@ -122,6 +121,21 @@ export class PlanModeController {
   private inputSourceForTurn: InputSource = "unknown";
   private internalExtensionBypassForTurn = false;
   private approvedPlanContinuationForTurn = false;
+  // ── Episode-guard markers ──────────────────────────────────────
+  // Each marker is keyed on a unique identifier for the current "episode"
+  // (artifact path for re-review, failure text for policy).  Once a
+  // follow-up has been queued, subsequent turn-ends with the same key are
+  // skipped — the post-run loop must stop, not self-continue forever.
+  //
+  // Reset strategy (applied consistently to both markers):
+  //   · restore()       — fresh session, no episode in progress.
+  //   · abort-approved  — abort ends the current episode; next normal
+  //                       turn-end may remind once for the new episode.
+  //   · approval        — run recovered; future unapproved episodes may
+  //                       remind once.
+  //   · policy pass     — artifact fixed; a new failure text queues again.
+  private reReviewReminderSentFor: string | null = null;
+  private policyReminderSentFor: string | null = null;
   constructor(private readonly pi: ExtensionAPI) {}
 
   restore(ctx: ExtensionContext): void {
@@ -132,6 +146,8 @@ export class PlanModeController {
     this.inputSourceForTurn = "unknown";
     this.internalExtensionBypassForTurn = false;
     this.approvedPlanContinuationForTurn = false;
+    this.reReviewReminderSentFor = null;
+    this.policyReminderSentFor = null;
   }
 
   persist(): void {
@@ -511,14 +527,32 @@ export class PlanModeController {
     if (turnWasAborted(event, ctx)) {
       if (this.state.abortApprovedExecution(latestArtifactPath)) {
         this.persist();
-        this.sendReviewWaitMessage(APPROVED_EXECUTION_ABORTED_REVIEW_MESSAGE);
+        // Allow one re-review reminder in the next (non-abort) episode.
+        this.reReviewReminderSentFor = null;
+        // Do NOT sendUserMessage() here. During agent_end the session still
+        // counts as streaming (_isAgentRunActive), so the message is queued
+        // as a follow-up and the post-run loop continues the agent with
+        // agent.continue(). Every following turn-end would hit
+        // approvedExecutionNeedsReReview() and queue another follow-up —
+        // an infinite self-continuation loop (the "keeps retrying after
+        // ESC" bug). Notify via UI instead and let the agent actually stop.
+        if (ctx.hasUI) {
+          ctx.ui.notify(
+            "Execution aborted. Submit the plan for re-review.",
+            "info",
+          );
+        }
         this.finishTurn(ctx);
         return;
       }
       // Aborted turns skip generic plan reminders; still surface this review
       // gate so the next turn does not appear idle while execution is blocked.
+      // Use notify() for the same reason — a queued follow-up would keep
+      // the agent loop self-continuing.
       if (this.approvedExecutionNeedsReReview(latestArtifactPath)) {
-        this.sendReviewWaitMessage(APPROVED_ARTIFACT_CHANGED_REVIEW_MESSAGE);
+        if (ctx.hasUI) {
+          ctx.ui.notify("Plan artifact changed. Submit for re-review.", "info");
+        }
         this.finishTurn(ctx);
         return;
       }
@@ -552,14 +586,34 @@ export class PlanModeController {
         { alreadyApproved: latestReviewArtifactApproved },
       );
       if (policyFailure) {
-        this.pi.sendUserMessage(policyFailure, { deliverAs: "followUp" });
+        // Queue the fix reminder only when the failure changed since the
+        // last queue (e.g. the artifact was rewritten). Re-queueing the
+        // identical failure on every turn-end would keep the post-run
+        // continuation loop spinning forever when the agent does not or
+        // cannot fix the artifact.
+        if (this.policyReminderSentFor !== policyFailure) {
+          this.policyReminderSentFor = policyFailure;
+          this.pi.sendUserMessage(policyFailure, { deliverAs: "followUp" });
+        }
         this.finishTurn(ctx);
         return;
       }
     }
+    // Validation passes or no artifact to validate — allow a future
+    // failure to remind without stale marker from an earlier episode.
+    this.policyReminderSentFor = null;
 
     if (this.approvedExecutionNeedsReReview(latestArtifactPath)) {
-      this.sendReviewWaitMessage(APPROVED_ARTIFACT_CHANGED_REVIEW_MESSAGE);
+      // Remind at most once per unapproved episode. Without this guard,
+      // every turn-end queues the same follow-up and the post-run loop
+      // keeps continuing the agent (agent.continue()) — an infinite
+      // self-continuation loop. This is the same "keeps retrying" bug,
+      // triggered when the user sends a new message after an ESC abort
+      // cleared the plan approval.
+      if (this.reReviewReminderSentFor !== latestArtifactPath) {
+        this.reReviewReminderSentFor = latestArtifactPath;
+        this.sendReviewWaitMessage(APPROVED_ARTIFACT_CHANGED_REVIEW_MESSAGE);
+      }
       this.finishTurn(ctx);
       return;
     }
@@ -667,6 +721,9 @@ export class PlanModeController {
     this.state.activePlanPath = pathToQueue;
     this.state.latestReviewArtifactPath = pathToQueue;
     this.state.reviewApprovedPlanPaths.add(pathToQueue);
+    // Approval recovers the run; allow a future unapproved episode to
+    // send its single re-review reminder again.
+    this.reReviewReminderSentFor = null;
     this.state.pendingApprovedPlanContinuationPath = pathToQueue;
     this.state.resumableApprovedPlanPath = pathToQueue;
     if (this.state.activeRun) {

--- a/extensions/plan-mode/review-lifecycle.test.ts
+++ b/extensions/plan-mode/review-lifecycle.test.ts
@@ -377,7 +377,11 @@ describe("plan-mode extension: review lifecycle", () => {
 
       await emitAbortedAgentEnd(harness, ctx);
 
-      expect(harness.api.sendUserMessage).toHaveBeenCalledWith(
+      expect(ctx.ui.notify).toHaveBeenCalledWith(
+        expect.stringContaining("Execution aborted"),
+        "info",
+      );
+      expect(harness.api.sendUserMessage).not.toHaveBeenCalledWith(
         expect.stringContaining("approved execution was aborted"),
         { deliverAs: "followUp" },
       );
@@ -458,7 +462,11 @@ describe("plan-mode extension: review lifecycle", () => {
 
       await emitAbortedAgentEnd(harness, ctx);
 
-      expect(harness.api.sendUserMessage).toHaveBeenCalledWith(
+      expect(ctx.ui.notify).toHaveBeenCalledWith(
+        expect.stringContaining("Execution aborted"),
+        "info",
+      );
+      expect(harness.api.sendUserMessage).not.toHaveBeenCalledWith(
         expect.stringContaining("approved execution was aborted"),
         { deliverAs: "followUp" },
       );
@@ -473,6 +481,50 @@ describe("plan-mode extension: review lifecycle", () => {
           planPath: demoPlanPath,
         },
       });
+    });
+  });
+
+  it("queues the re-review reminder at most once per unapproved episode", async () => {
+    await withTempCtx(async (ctx) => {
+      writePlanArtifact(ctx.cwd, demoPlanPath, validPlanContent);
+      const harness = buildHarness();
+      planModeExtension(harness.api as unknown as ExtensionAPI);
+      await harness.emit("session_start", {}, ctx);
+      await startApprovedDemoRun(harness, ctx);
+
+      // ESC abort: notify only, no follow-up queued, agent stops.
+      await emitAbortedAgentEnd(harness, ctx);
+      // Clear any setup-phase sendUserMessage calls (currently none —
+      // abort uses notify — but guarded so a future implementation
+      // change doesn't silently inflate the count below).
+      harness.api.sendUserMessage.mockClear();
+
+      // Next user turn ends normally: the re-review reminder is queued once.
+      await harness.emit("agent_end", { messages: [] }, ctx);
+      expect(harness.api.sendUserMessage).toHaveBeenCalledTimes(1);
+      expect(harness.api.sendUserMessage).toHaveBeenCalledWith(
+        expect.stringContaining("approved artifact changed"),
+        { deliverAs: "followUp" },
+      );
+
+      // The continuation turn also ends without re-approval: no second
+      // reminder — the post-run loop must stop instead of self-continuing.
+      await harness.emit("agent_end", { messages: [] }, ctx);
+      expect(harness.api.sendUserMessage).toHaveBeenCalledTimes(1);
+
+      // After the plan is approved again, a new abort episode may remind
+      // once more.
+      await emitApprovedReview(harness, ctx, demoPlanPath);
+      // Clear pre-episode noise so the one allowed re-review message is
+      // the only sendUserMessage in this block.
+      harness.api.sendUserMessage.mockClear();
+      await emitAbortedAgentEnd(harness, ctx);
+      await harness.emit("agent_end", { messages: [] }, ctx);
+      expect(harness.api.sendUserMessage).toHaveBeenCalledTimes(1);
+      expect(harness.api.sendUserMessage).toHaveBeenCalledWith(
+        expect.stringContaining("approved artifact changed"),
+        { deliverAs: "followUp" },
+      );
     });
   });
 
@@ -567,6 +619,57 @@ describe("plan-mode extension: review lifecycle", () => {
         expect.stringContaining("plannotator_auto_submit_review"),
       );
       expect(options).toEqual({ deliverAs: "followUp" });
+    });
+  });
+
+  it("queues the policy-fix reminder again only when the failure changes", async () => {
+    await withTempCtx(async (ctx) => {
+      const today = new Date().toISOString().slice(0, 10);
+      const planPath = `.pi/plans/pi-kit/plan/${today}-demo.md`;
+      writePlanArtifact(ctx.cwd, planPath, invalidPlanContent);
+      const { harness } = await startPlanModeSession("act", ctx);
+      await harness.runTool(
+        PLAN_MODE_TODO_TOOL,
+        {
+          action: "set",
+          items: [{ text: "修复 plan 格式", status: "todo" }],
+        },
+        ctx,
+      );
+      await emitReviewArtifactWrite(harness, ctx, planPath);
+
+      // First turn-end with an invalid artifact: reminder is queued once.
+      await harness.emit("agent_end", { messages: [] }, ctx);
+      expect(harness.api.sendUserMessage).toHaveBeenCalledTimes(1);
+
+      // Same failure on the next turn-end: no re-queue — the post-run
+      // loop must stop instead of self-continuing forever.
+      await harness.emit("agent_end", { messages: [] }, ctx);
+      expect(harness.api.sendUserMessage).toHaveBeenCalledTimes(1);
+
+      // Artifact rewritten but still invalid with a different failure:
+      // the new failure text is queued again.
+      // Note: writePlanArtifact bypasses the tool-result →
+      // markReviewArtifactWritten path, but validateArtifactPolicyForPath
+      // reads from disk directly, so the guard (which keys on the
+      // formatted failure text) sees the new content regardless.
+      writePlanArtifact(
+        ctx.cwd,
+        planPath,
+        validPlanContent.replace("## Decisions", "## Notes"),
+      );
+      await harness.emit("agent_end", { messages: [] }, ctx);
+      expect(harness.api.sendUserMessage).toHaveBeenCalledTimes(2);
+
+      // Artifact fixed: no further policy reminders.
+      writePlanArtifact(ctx.cwd, planPath, validPlanContent);
+      await harness.emit("agent_end", { messages: [] }, ctx);
+      const policyCalls = harness.api.sendUserMessage.mock.calls.filter(
+        ([message]) =>
+          typeof message === "string" &&
+          message.includes("Plan Mode artifact policy"),
+      );
+      expect(policyCalls).toHaveLength(2);
     });
   });
 


### PR DESCRIPTION
- Abort path: replace sendUserMessage with ctx.ui.notify so the agent actually stops instead of re-queuing a follow-up that restarts the loop
- Non-abort path (re-review guard): queue the "approved artifact changed" reminder at most once per unapproved episode; subsequent turn-ends skip
- Non-abort path (policy guard): queue the policy-fix reminder only when the failure text changes (artifact rewritten); identical text is skipped
- Approval and abort reset the episode guards so a new cycle can remind once more
- Document episode-guard reset strategy inline (restore / abort / approval / policy pass)
- Move policyReminderSentFor reset outside the if(latestArtifactPath) block so null-path episodes also clear the stale marker
- Update existing abort tests from sendUserMessage to notify assertions
- Add tests covering guard-invariance (identical state) and guard-reset (approval then re-abort); add policy-failure content-key guard test
- Annotate mockClear() and writePlanArtifact shortcuts for clarity