### PR TITLE
feat(extensions): add spaced-repetition extension for review notes

### DIFF
--- a/extensions/spaced-repetition/cards.test.ts
+++ b/extensions/spaced-repetition/cards.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ParsedConcept,
+  evaluateSubstance,
+  extractBodySections,
+  extractTags,
+  extractTitle,
+  generateAllCards,
+  generateConnectionCard,
+  generateQaCard,
+  generateSummaryCard,
+  parseConceptContent,
+  summarizeSection,
+} from "./cards.js";
+
+// ── Test fixtures ──────────────────────────────────────
+
+const RICH_CONCEPT = `---
+type: Concept
+_icon: note
+tags: [go, golang, http, web-server]
+---
+
+# Go HTTP Server
+
+Go's standard library provides a production-ready HTTP server in the \`net/http\` package. The default multiplexer, \`ServeMux\`, implements a Command pattern where each URL pattern maps to a dedicated handler function registered via \`HandleFunc\`.
+
+The server supports middleware composition, graceful shutdown, and HTTP/2 via TLS.
+
+## Common Causes
+
+First common cause paragraph. Second sentence of the cause.
+
+## Detection and Prevention
+
+Use goleak package. Monitor with runtime.NumGoroutine.
+
+## Sources
+
+- [[Wiki/Summaries/Calendar/DailyNotes/2024/2024-07-23.summary]]
+`;
+
+const THIN_CONCEPT = `---
+type: Concept
+_icon: note
+tags: []
+---
+
+# Async/Await
+
+## Sources
+
+- [[Wiki/Summaries/Calendar/DailyNotes/2026/2026-02-02.summary]]
+`;
+
+const CONCEPT_WITHOUT_SECTIONS = `---
+type: Concept
+_icon: note
+tags: [test]
+---
+
+# Simple Concept
+
+This is a simple concept with only one paragraph. It has enough text to be considered substantive but no ## sections.
+
+## Sources
+
+- [[Wiki/Summaries/...]]
+`;
+
+// ── parseConceptContent ────────────────────────────────
+
+describe("parseConceptContent", () => {
+  it("should parse rich concept with tags and sections", () => {
+    const result = parseConceptContent(
+      RICH_CONCEPT,
+      "go-http-server",
+      "/path/go-http-server.md",
+    );
+
+    expect(result.slug).toBe("go-http-server");
+    expect(result.title).toBe("Go HTTP Server");
+    expect(result.tags).toEqual(["go", "golang", "http", "web-server"]);
+    expect(result.hasSubstance).toBe(true);
+    expect(result.source).toBe("/path/go-http-server.md");
+  });
+
+  it("should parse thin concept without substance", () => {
+    const result = parseConceptContent(
+      THIN_CONCEPT,
+      "async-await",
+      "/path/async-await.md",
+    );
+
+    expect(result.slug).toBe("async-await");
+    expect(result.title).toBe("Async/Await");
+    expect(result.tags).toEqual([]);
+    expect(result.hasSubstance).toBe(false);
+  });
+
+  it("should handle concept without ## sections", () => {
+    const result = parseConceptContent(
+      CONCEPT_WITHOUT_SECTIONS,
+      "simple-concept",
+      "/path/simple.md",
+    );
+
+    expect(result.title).toBe("Simple Concept");
+    expect(result.tags).toEqual(["test"]);
+    expect(result.hasSubstance).toBe(true);
+    expect(result.bodySections).toHaveLength(1);
+    expect(result.bodySections[0].heading).toBe("概述");
+  });
+});
+
+// ── extractTags ────────────────────────────────────────
+
+describe("extractTags", () => {
+  it("should extract tags from frontmatter", () => {
+    const tags = extractTags(RICH_CONCEPT);
+    expect(tags).toEqual(["go", "golang", "http", "web-server"]);
+  });
+
+  it("should return empty array when no tags", () => {
+    const tags = extractTags(THIN_CONCEPT);
+    expect(tags).toEqual([]);
+  });
+
+  it("should return empty array when no frontmatter", () => {
+    const tags = extractTags("# Just a title\n\nSome content");
+    expect(tags).toEqual([]);
+  });
+});
+
+// ── extractTitle ───────────────────────────────────────
+
+describe("extractTitle", () => {
+  it("should extract title from # heading", () => {
+    expect(extractTitle(RICH_CONCEPT)).toBe("Go HTTP Server");
+  });
+
+  it("should return slug-based fallback when no # heading", () => {
+    const result = extractTitle("---\ntags: []\n---\n\nSome content");
+    // No # heading found, slug not provided — returns "Some" from fallback
+    expect(typeof result).toBe("string");
+  });
+});
+
+// ── extractBodySections ────────────────────────────────
+
+describe("extractBodySections", () => {
+  it("should split body into sections by ## headings", () => {
+    const sections = extractBodySections(RICH_CONCEPT);
+
+    expect(sections.length).toBeGreaterThanOrEqual(2);
+
+    // First section should be "概述" (content before first ##)
+    const overviewIdx = sections.findIndex((s) => s.heading === "概述");
+    expect(overviewIdx).not.toBe(-1);
+
+    // Should have Common Causes and Detection
+    const causesIdx = sections.findIndex((s) => s.heading === "Common Causes");
+    expect(causesIdx).not.toBe(-1);
+
+    const detectIdx = sections.findIndex(
+      (s) => s.heading === "Detection and Prevention",
+    );
+    expect(detectIdx).not.toBe(-1);
+  });
+
+  it("should exclude ## Sources section", () => {
+    const sections = extractBodySections(RICH_CONCEPT);
+    const sourcesSection = sections.find((s) => s.heading === "Sources");
+    expect(sourcesSection).toBeUndefined();
+  });
+
+  it("should return empty for thin concept", () => {
+    const sections = extractBodySections(THIN_CONCEPT);
+    expect(sections).toHaveLength(0);
+  });
+});
+
+// ── evaluateSubstance ──────────────────────────────────
+
+describe("evaluateSubstance", () => {
+  it("should return true for rich concept", () => {
+    const parsed = parseConceptContent(
+      RICH_CONCEPT,
+      "go-http-server",
+      "/path.md",
+    );
+    expect(
+      evaluateSubstance(parsed.bodySections, RICH_CONCEPT),
+    ).toBe(true);
+  });
+
+  it("should return false for thin concept", () => {
+    const parsed = parseConceptContent(
+      THIN_CONCEPT,
+      "async-await",
+      "/path.md",
+    );
+    expect(
+      evaluateSubstance(parsed.bodySections, THIN_CONCEPT),
+    ).toBe(false);
+  });
+});
+
+// ── Card generation ────────────────────────────────────
+
+describe("generateQaCard", () => {
+  it("should create a QA card with Chinese question", () => {
+    const parsed = parseConceptContent(
+      RICH_CONCEPT,
+      "go-http-server",
+      "/path.md",
+    );
+    const card = generateQaCard(parsed);
+
+    expect(card.cardType).toBe("qa");
+    expect(card.question).toContain("什么是 Go HTTP Server");
+    expect(card.answer.length).toBeGreaterThanOrEqual(2);
+    expect(card.tags).toContain("go");
+  });
+});
+
+describe("generateSummaryCard", () => {
+  it("should create a summary card with condensed answer", () => {
+    const parsed = parseConceptContent(
+      RICH_CONCEPT,
+      "go-http-server",
+      "/path.md",
+    );
+    const card = generateSummaryCard(parsed);
+
+    expect(card.cardType).toBe("summary");
+    expect(card.question).toContain("回顾 Go HTTP Server");
+    expect(card.answer.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("generateConnectionCard", () => {
+  it("should create a connection card linking two concepts", () => {
+    const parsed = parseConceptContent(
+      RICH_CONCEPT,
+      "go-http-server",
+      "/path.md",
+    );
+    const card = generateConnectionCard(parsed, "Context Cancellation");
+
+    expect(card.cardType).toBe("connection");
+    expect(card.question).toContain("Go HTTP Server 和 Context Cancellation");
+    expect(card.relatedConcept).toBe("Context Cancellation");
+  });
+});
+
+describe("generateAllCards", () => {
+  it("should generate QA + Summary for concept without related", () => {
+    const parsed = parseConceptContent(
+      RICH_CONCEPT,
+      "go-http-server",
+      "/path.md",
+    );
+    const cards = generateAllCards(parsed);
+
+    expect(cards).toHaveLength(2);
+    expect(cards.map((c) => c.cardType)).toEqual(["qa", "summary"]);
+  });
+
+  it("should generate QA + Summary + Connection when related given", () => {
+    const parsed = parseConceptContent(
+      RICH_CONCEPT,
+      "go-http-server",
+      "/path.md",
+    );
+    const cards = generateAllCards(parsed, "Context Cancellation");
+
+    expect(cards).toHaveLength(3);
+    expect(cards.map((c) => c.cardType)).toEqual([
+      "qa",
+      "summary",
+      "connection",
+    ]);
+  });
+});
+
+// ── summarizeSection ───────────────────────────────────
+
+describe("summarizeSection", () => {
+  it("should limit to approximately 3 sentences", () => {
+    const long = "First sentence. Second sentence. Third sentence. Fourth sentence. Fifth sentence.";
+    const result = summarizeSection(long);
+    // First 3 sentences
+    expect(result).toContain("First sentence");
+    expect(result).toContain("Third sentence");
+    expect(result).not.toContain("Fifth sentence");
+  });
+
+  it("should truncate when over 200 chars", () => {
+    const veryLong =
+      "This is a very long sentence that goes on and on and on about various topics. ".repeat(6);
+    const result = summarizeSection(veryLong);
+    // Should be truncated to ~200 chars with ellipsis
+    expect(result.length).toBeLessThanOrEqual(203); // 200 + ellipsis
+    expect(result).toMatch(/…$/);
+  });
+});

--- a/extensions/spaced-repetition/cards.ts
+++ b/extensions/spaced-repetition/cards.ts
@@ -1,0 +1,423 @@
+/**
+ * cards.ts — 概念解析、卡片生成、格式化
+ *
+ * 纯函数，无 IO，无副作用。
+ *
+ * 概念文件格式（frontmatter + body + ## Sources）：
+ * ```markdown
+ * ---
+ * type: Concept
+ * tags: [go, http]
+ * ---
+ *
+ * # Title
+ *
+ * Body text...
+ *
+ * ## Section Heading
+ *
+ * More body...
+ *
+ * ## Sources
+ *
+ * - [[Wiki/...]]
+ * ```
+ */
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+/** 答案的一个结构化分段 */
+export interface AnswerSection {
+  heading: string;  // 中文标题
+  content: string;  // 该分段的内容
+}
+
+/** 卡片类型 */
+export type CardType = "qa" | "summary" | "connection";
+
+/** 复习卡片 */
+export interface ReviewCard {
+  concept: string;                // 概念名（英文）
+  slug: string;                   // 文件名
+  question: string;               // 中文问题
+  answer: AnswerSection[];        // 结构化分段答案
+  tags: string[];                 // 标签
+  source: string;                 // 源文件路径
+  cardType: CardType;
+
+  // Type C 专用
+  relatedConcept?: string;
+  relationDescription?: string;
+}
+
+/** 解析后的概念 */
+export interface ParsedConcept {
+  slug: string;                   // 文件名
+  title: string;                  // 标题（# Title）
+  tags: string[];                 // frontmatter tags
+  bodySections: BodySection[];    // 正文分段
+  hasSubstance: boolean;          // 是否有正文内容
+  source: string;                 // 源文件路径
+}
+
+/** 正文分段 */
+export interface BodySection {
+  heading: string;                // 段落标题（英文原文）
+  content: string;                // 段落内容
+}
+
+// ── 常量 ───────────────────────────────────────────────────────────────────
+
+/** 判断一个概念是否「有正文」的最小字符数（不含 frontmatter 和 sources） */
+export const MIN_SUBSTANCE_CHARS = 50;
+
+/** Type C 关联描述的文案模板 */
+const RELATION_TEMPLATES: Record<string, string> = {
+  default: "关联概念",
+};
+
+// ── 概念解析 ──────────────────────────────────────────
+
+/**
+ * 从概念文件内容中解析出结构化数据。
+ *
+ * 纯函数 — 只解析输入字符串，不访问文件系统。
+ *
+ * @param content 概念文件的完整文本内容
+ * @param slug 概念文件名（不含路径和扩展名）
+ * @param source 源文件路径
+ * @returns 解析后的概念
+ */
+export function parseConceptContent(
+  content: string,
+  slug: string,
+  source: string,
+): ParsedConcept {
+  const tags = extractTags(content);
+  const title = extractTitle(content);
+  const bodySections = extractBodySections(content);
+  const hasSubstance = evaluateSubstance(bodySections, content);
+
+  return { slug, title, tags, bodySections, hasSubstance, source };
+}
+
+/**
+ * 从 frontmatter 提取 tags。
+ *
+ * @param content 完整文件内容
+ * @returns 标签数组
+ */
+export function extractTags(content: string): string[] {
+  const match = content.match(/^---\n[\s\S]*?\n---/);
+  if (!match) return [];
+
+  const frontmatter = match[0];
+  const tagsMatch = frontmatter.match(/tags:\s*\[([^\]]*)\]/);
+  if (!tagsMatch) return [];
+
+  return tagsMatch[1]
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+/**
+ * 从 # Title 行提取标题。
+ *
+ * @param content 完整文件内容
+ * @returns 标题文本，如找不到返回 slug
+ */
+export function extractTitle(content: string): string {
+  const match = content.match(/^#\s+(.+)$/m);
+  return match ? match[1].trim() : slugToTitle(content);
+}
+
+/**
+ * 从 slug 推断标题（当没有 # Title 时的回退）。
+ */
+function slugToTitle(slug: string): string {
+  return slug
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/**
+ * 从正文提取结构化分段。
+ *
+ * 策略：
+ * 1. 移除 frontmatter（--- ... ---）
+ * 2. 移除 # 标题行
+ * 3. 移除 ## Sources 及其之后的内容
+ * 4. 按 ## 标题分段，每段包括标题及其后的段落
+ * 5. 无 ## 标题的内容归为「概述」
+ *
+ * @param content 完整文件内容
+ * @returns 正文分段数组
+ */
+export function extractBodySections(content: string): BodySection[] {
+  // 移除 frontmatter
+  let body = content.replace(/^---[\s\S]*?\n---\n/, "").trim();
+
+  // 移除 # 标题行
+  body = body.replace(/^#\s+.*$/m, "").trim();
+
+  // 移除 ## Sources 及之后的内容
+  const sourcesIndex = body.search(/^##\s+Sources/m);
+  if (sourcesIndex !== -1) {
+    body = body.slice(0, sourcesIndex).trim();
+  }
+
+  if (!body) return [];
+
+  // 按 ## 标题分段
+  const sections: BodySection[] = [];
+  const headingPattern = /^##\s+(.+)$/gm;
+  let lastIndex = 0;
+  let lastHeading = "";
+
+  // 查找第一个 ## 标题
+  const firstMatch = headingPattern.exec(body);
+
+  if (!firstMatch) {
+    // 没有 ## 标题，整个正文作为「概述」
+    return [{ heading: "概述", content: body.trim() }];
+  }
+
+  // 第一个 ## 标题之前的内容作为「概述」
+  const beforeFirstHeading = body.slice(0, firstMatch.index).trim();
+  if (beforeFirstHeading) {
+    sections.push({ heading: "概述", content: beforeFirstHeading });
+  }
+
+  lastIndex = firstMatch.index;
+  lastHeading = firstMatch[1].trim();
+  let lastMatch = firstMatch;
+
+  // 遍历后续 ## 标题
+  let match: RegExpExecArray | null;
+  while ((match = headingPattern.exec(body)) !== null) {
+    // 从上个标题到这个标题之间的内容
+    const sectionContent = body
+      .slice(lastMatch.index + lastMatch[0].length, match.index)
+      .trim();
+    if (sectionContent) {
+      sections.push({ heading: lastHeading, content: sectionContent });
+    }
+    lastIndex = match.index;
+    lastHeading = match[1].trim();
+    lastMatch = match;
+  }
+
+  // 最后一个 ## 标题后的内容
+  const afterLast = body.slice(lastMatch.index + lastMatch[0].length).trim();
+  if (afterLast) {
+    sections.push({ heading: lastHeading, content: afterLast });
+  }
+
+  return sections;
+}
+
+/**
+ * 判断概念是否有充分的正文内容。
+ *
+ * 策略：bodySections 的总字符数 >= MIN_SUBSTANCE_CHARS
+ *
+ * @param bodySections 正文分段
+ * @param content 原始内容（备用）
+ * @returns 是否有正文
+ */
+export function evaluateSubstance(
+  bodySections: BodySection[],
+  content: string,
+): boolean {
+  if (bodySections.length === 0) return false;
+
+  const totalChars = bodySections.reduce(
+    (sum, s) => sum + s.heading.length + s.content.length,
+    0,
+  );
+  if (totalChars >= MIN_SUBSTANCE_CHARS) return true;
+
+  // 备用：检查原始内容中 # 标题之后、## Sources 之前的字符数
+  const bodyMatch = content.match(/^#\s+.*$/m);
+  if (!bodyMatch) return false;
+
+  const afterTitle = content.slice(bodyMatch.index! + bodyMatch[0].length);
+  const sourcesIdx = afterTitle.search(/^##\s+Sources/m);
+  const bodyText =
+    sourcesIdx !== -1 ? afterTitle.slice(0, sourcesIdx) : afterTitle;
+
+  return bodyText.trim().length >= MIN_SUBSTANCE_CHARS;
+}
+
+// ── 卡片生成 ──────────────────────────────────────────
+
+/**
+ * 生成 Type A（概念问答）卡片。
+ *
+ * @param concept 解析后的概念
+ * @returns 复习卡片
+ */
+export function generateQaCard(concept: ParsedConcept): ReviewCard {
+  return {
+    concept: concept.title,
+    slug: concept.slug,
+    question: `什么是 ${concept.title}？`,
+    answer: concept.bodySections.map(sectionToAnswerSection),
+    tags: concept.tags,
+    source: concept.source,
+    cardType: "qa",
+  };
+}
+
+/**
+ * 生成 Type B（要点回顾）卡片。
+ *
+ * 从 body sections 中提取关键信息，精简为要点列表。
+ *
+ * @param concept 解析后的概念
+ * @returns 复习卡片
+ */
+export function generateSummaryCard(concept: ParsedConcept): ReviewCard {
+  // 精简每个段落为要点
+  const answer = concept.bodySections.map((s) => ({
+    heading: s.heading,
+    content: summarizeSection(s.content),
+  }));
+
+  return {
+    concept: concept.title,
+    slug: concept.slug,
+    question: `回顾 ${concept.title} 的核心要点`,
+    answer,
+    tags: concept.tags,
+    source: concept.source,
+    cardType: "summary",
+  };
+}
+
+/**
+ * 生成 Type C（关联连线）卡片。
+ *
+ * @param concept 解析后的概念
+ * @param relatedConcept 关联的概念名
+ * @param relationDescription 关系描述
+ * @returns 复习卡片
+ */
+export function generateConnectionCard(
+  concept: ParsedConcept,
+  relatedConcept: string,
+  relationDescription?: string,
+): ReviewCard {
+  return {
+    concept: concept.title,
+    slug: concept.slug,
+    question: `${concept.title} 和 ${relatedConcept} 有什么关系？`,
+    answer: [
+      {
+        heading: concept.title,
+        content: concept.bodySections.map((s) => s.content).join("\n\n"),
+      },
+      {
+        heading: relationDescription ?? RELATION_TEMPLATES.default,
+        content: relatedConcept,
+      },
+    ],
+    tags: concept.tags,
+    source: concept.source,
+    cardType: "connection",
+    relatedConcept,
+    relationDescription,
+  };
+}
+
+/**
+ * 为某个概念生成所有可能的卡片。
+ *
+ * @param concept 解析后的概念
+ * @param relatedConcept 可选：关联概念名（用于 Type C）
+ * @param relationDescription 可选：关系描述（用于 Type C）
+ * @returns 卡片数组
+ */
+export function generateAllCards(
+  concept: ParsedConcept,
+  relatedConcept?: string,
+  relationDescription?: string,
+): ReviewCard[] {
+  const cards: ReviewCard[] = [];
+
+  cards.push(generateQaCard(concept));
+  cards.push(generateSummaryCard(concept));
+
+  if (relatedConcept) {
+    cards.push(
+      generateConnectionCard(concept, relatedConcept, relationDescription),
+    );
+  }
+
+  return cards;
+}
+
+// ── 格式化 ────────────────────────────────────────────
+
+/**
+ * BodySection → AnswerSection（标题翻译）
+ *
+ * 将英文标题映射为中文标题。
+ */
+function sectionToAnswerSection(section: BodySection): AnswerSection {
+  const heading = translateHeading(section.heading);
+  return { heading, content: section.content };
+}
+
+/**
+ * 英文标题 → 中文标题映射。
+ */
+function translateHeading(heading: string): string {
+  const map: Record<string, string> = {
+    概述: "概述",
+    "Common Causes": "常见原因",
+    "Detection and Prevention": "检测与预防",
+    "Detection": "检测方法",
+    "Prevention": "预防措施",
+    "Examples": "示例",
+    "Usage": "用法",
+    "Implementation": "实现",
+    "Performance": "性能",
+    "Comparison": "对比",
+    "Design": "设计",
+    "Architecture": "架构",
+    "Background": "背景",
+    "Motivation": "动机",
+    "Key Concepts": "核心概念",
+    "How it works": "工作原理",
+    "How It Works": "工作原理",
+  };
+
+  return map[heading] ?? heading;
+}
+
+/**
+ * 精简段落内容为要点。
+ *
+ * 策略：取前 3 句，或前 200 字符（取其短者）。
+ */
+export function summarizeSection(content: string): string {
+  // 按句号、问号、感叹号分割
+  const sentences = content
+    .split(/(?<=[。？！.!?])\s*/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  // 取前 3 句
+  const selected = sentences.slice(0, 3);
+  let result = selected.join("\n");
+
+  // 限制长度 200 字符
+  if (result.length > 200) {
+    result = result.slice(0, 200) + "…";
+  }
+
+  return result;
+}

--- a/extensions/spaced-repetition/index.ts
+++ b/extensions/spaced-repetition/index.ts
@@ -1,0 +1,400 @@
+/**
+ * spaced-repetition — Pi 扩展入口
+ *
+ * 注册 /recall-notes 命令，编排完整复习流程。
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@earendil-works/pi-coding-agent";
+import { createLogger } from "../shared/logger.ts";
+import { loadSettings } from "../shared/settings.ts";
+import { sendTelegramNotification, isTelegramConfigured } from "../shared/telegram.ts";
+
+import {
+  generateAllCards,
+  parseConceptContent,
+  type ParsedConcept,
+} from "./cards.ts";
+import { computeNextReview, type ConceptEntry } from "./sm2.ts";
+import { createNewEntry } from "./sm2.ts";
+import {
+  type ReviewState,
+  loadState,
+  saveState,
+  selectConcepts,
+  summarizeState,
+  syncConcepts,
+} from "./state.ts";
+import { formatCardsForTelegram } from "./telegram.ts";
+import { createCardWidget, type CardResult } from "./widget.ts";
+
+// ── Logger ──────────────────────────────────────────────
+
+const log = createLogger("spaced-repetition", { stderr: null });
+
+// ── Constants ────────────────────────────────────────────
+
+const HOME = homedir();
+const DEFAULT_KNOWLEDGE_BASE = path.join(HOME, "work", "notes");
+const DEFAULT_CONCEPTS_DIR = "Wiki/Concepts";
+const DEFAULT_REVIEW_DIR = "Review";
+const DEFAULT_CARDS_PER_SESSION = 5;
+
+// ── Types ──────────────────────────────────────────────
+
+interface SpacedRepetitionSettings {
+  spacedRepetition?: {
+    knowledgeBase?: string;
+    conceptsDir?: string;
+    reviewDir?: string;
+    cardsPerSession?: number;
+    enableTelegram?: boolean;
+  };
+}
+
+interface ResolvedConfig {
+  knowledgeBaseDir: string;
+  conceptsDir: string;
+  reviewDir: string;
+  reviewFilePath: string;
+  stateFilePath: string;
+  cardsPerSession: number;
+  enableTelegram: boolean;
+}
+
+// ── Config ──────────────────────────────────────────────
+
+function loadConfig(cwd: string): ResolvedConfig {
+  const settings = loadSettings(cwd).merged as SpacedRepetitionSettings;
+  const ext = settings.spacedRepetition ?? {};
+
+  const knowledgeBaseDir = path.resolve(
+    ext.knowledgeBase ?? DEFAULT_KNOWLEDGE_BASE,
+  );
+  const conceptsDir = ext.conceptsDir ?? DEFAULT_CONCEPTS_DIR;
+  const reviewDir = ext.reviewDir ?? DEFAULT_REVIEW_DIR;
+  const cardsPerSession = ext.cardsPerSession ?? DEFAULT_CARDS_PER_SESSION;
+  const enableTelegram = ext.enableTelegram ?? isTelegramConfigured(cwd);
+
+  const conceptsAbs = path.join(knowledgeBaseDir, conceptsDir);
+  const reviewAbs = path.join(knowledgeBaseDir, reviewDir);
+
+  const now = new Date();
+  const monthFile = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}.md`;
+  const reviewFilePath = path.join(reviewAbs, monthFile);
+  const stateFilePath = path.join(reviewAbs, ".state.json");
+
+  return {
+    knowledgeBaseDir,
+    conceptsDir: conceptsAbs,
+    reviewDir: reviewAbs,
+    reviewFilePath,
+    stateFilePath,
+    cardsPerSession,
+    enableTelegram,
+  };
+}
+
+// ── File operations ─────────────────────────────────────
+
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+/**
+ * 扫描概念目录，返回所有概念文件（不含目录）。
+ */
+function scanConceptFiles(conceptsDir: string): string[] {
+  try {
+    const entries = fs.readdirSync(conceptsDir);
+    return entries
+      .filter((e) => e.endsWith(".md"))
+      .map((e) => e.replace(/\.md$/, ""));
+  } catch (err) {
+    log.warn("failed to scan concepts dir", {
+      dir: conceptsDir,
+      error: String(err),
+    });
+    return [];
+  }
+}
+
+/**
+ * 读取概念文件并解析。
+ */
+function readConcept(
+  conceptsDir: string,
+  slug: string,
+): ParsedConcept | null {
+  const filePath = path.join(conceptsDir, `${slug}.md`);
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    return parseConceptContent(content, slug, filePath);
+  } catch (err) {
+    log.warn("failed to read concept", {
+      slug,
+      error: String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * 通过 qmd search 查找关联概念。
+ *
+ * 返回第一个非自身的概念名，如无可返回 undefined。
+ */
+async function findRelatedConcept(
+  concept: ParsedConcept,
+): Promise<string | undefined> {
+  const keywords = [concept.title, ...concept.tags].filter(Boolean).join(" ");
+  if (!keywords) return undefined;
+
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileAsync = promisify(execFile);
+
+    const { stdout } = await execFileAsync(
+      "qmd",
+      [
+        "search",
+        keywords,
+        "--json",
+        "-n",
+        "5",
+      ],
+      {
+        cwd: process.cwd(),
+        timeout: 15_000,
+      },
+    );
+
+    const results = JSON.parse(stdout) as Array<{
+      file: string;
+      title: string;
+      score: number;
+    }>;
+
+    if (!Array.isArray(results) || results.length === 0) return undefined;
+
+    // 找到第一个不在 Concepts/ 中或不同名的结果
+    const other = results.find(
+      (r) => !r.file.includes(`/Concepts/${concept.slug}`),
+    );
+    return other?.title || results[1]?.title || undefined;
+  } catch (err) {
+    log.warn("qmd search failed for related concept", {
+      concept: concept.slug,
+      error: String(err),
+    });
+    return undefined;
+  }
+}
+
+/**
+ * 追加当日复习记录到月度文件。
+ */
+function appendToReviewFile(
+  filePath: string,
+  dateStr: string,
+  results: CardResult[],
+  cards: { slug: string; concept: string }[],
+): void {
+  ensureDir(path.dirname(filePath));
+
+  // 当月度文件不存在时，创建并写入标题
+  let content = "";
+  if (!fs.existsSync(filePath)) {
+    content = `# 复习记录\n\n`;
+  } else {
+    content = fs.readFileSync(filePath, "utf-8");
+  }
+
+  // 追加当天的记录
+  const daySection = `## ${dateStr}\n\n`;
+  const entries = results.map((r) => {
+    const card = cards.find((c) => c.slug === r.slug);
+    const gradeStr = r.grade === 4 ? "✅ 记得" : "❌ 忘了";
+    return `- ${card?.concept ?? r.slug}: ${gradeStr}`;
+  });
+
+  content += `${daySection}${entries.join("\n")}\n\n`;
+  fs.writeFileSync(filePath, content, "utf-8");
+}
+
+// ── 主流程 ──────────────────────────────────────────────
+
+async function runRecallSession(
+  ctx: ExtensionCommandContext,
+  config: ResolvedConfig,
+): Promise<void> {
+  const now = Date.now();
+
+  // 1. 扫描概念
+  const allSlugs = scanConceptFiles(config.conceptsDir);
+  if (allSlugs.length === 0) {
+    ctx.ui.notify("未找到概念文件", "warning");
+    return;
+  }
+  log.info("concepts scanned", { count: allSlugs.length });
+
+  // 2. 加载状态并同步新概念
+  const state = await loadState(config.stateFilePath);
+  const synced = syncConcepts(state, new Set(allSlugs), now);
+
+  // 3. 选择本批概念
+  const selectedSlugs = selectConcepts(synced, config.cardsPerSession, now);
+  if (selectedSlugs.length === 0) {
+    ctx.ui.notify("没有到期的复习卡片 🎉", "info");
+    return;
+  }
+  log.info("selected concepts", {
+    slugs: selectedSlugs,
+    count: selectedSlugs.length,
+  });
+
+  // 4. 读取概念并生成卡片
+  const parsedConcepts: ParsedConcept[] = [];
+  for (const slug of selectedSlugs) {
+    const parsed = readConcept(config.conceptsDir, slug);
+    if (parsed && parsed.hasSubstance) {
+      parsedConcepts.push(parsed);
+    } else {
+      log.info("skipping thin concept", { slug });
+    }
+  }
+
+  if (parsedConcepts.length === 0) {
+    ctx.ui.notify("选中的概念都无正文内容", "warning");
+    return;
+  }
+
+  // 5. 生成卡片（对每个概念尝试发现关联）
+  const allCards: Array<{ card: import("./cards.ts").ReviewCard; slug: string; concept: string }> = [];
+  for (const parsed of parsedConcepts) {
+    // 尝试找关联概念（Type C）
+    let relatedConcept: string | undefined;
+    if (allCards.length < config.cardsPerSession) {
+      relatedConcept = await findRelatedConcept(parsed);
+    }
+
+    const cards = generateAllCards(parsed, relatedConcept);
+
+    // 取前 N 张确保不超过 cardsPerSession
+    for (const card of cards) {
+      if (allCards.length >= config.cardsPerSession) break;
+      allCards.push({ card, slug: parsed.slug, concept: parsed.title });
+    }
+    if (allCards.length >= config.cardsPerSession) break;
+  }
+
+  const reviewCards = allCards.map((c) => c.card);
+
+  // 6. 打开交互式 widget
+  ctx.ui.notify(
+    `打开复习：${reviewCards.length} 张卡片`,
+    "info",
+  );
+
+  const widgetResult = await ctx.ui.custom<{
+    results: CardResult[];
+    cancelled: boolean;
+  }>((tui, theme, _kb, done) =>
+    createCardWidget(reviewCards, theme, done),
+  );
+
+  if (widgetResult.cancelled) {
+    ctx.ui.notify("复习已取消", "info");
+    // 已评分的结果仍然保存
+    if (widgetResult.results.length === 0) return;
+  }
+
+  // 7. 更新 SM-2 状态
+  const updatedConcepts = { ...synced.concepts };
+  for (const result of widgetResult.results) {
+    const entry = updatedConcepts[result.slug];
+    if (entry) {
+      updatedConcepts[result.slug] = computeNextReview(
+        result.grade,
+        entry,
+        now,
+      );
+    }
+  }
+
+  const updatedState: ReviewState = {
+    ...synced,
+    concepts: updatedConcepts,
+  };
+
+  // 8. 保存状态
+  ensureDir(config.reviewDir);
+  await saveState(config.stateFilePath, updatedState);
+
+  // 9. 追加到月度文件
+  const dateStr = new Date().toISOString().slice(0, 10);
+  appendToReviewFile(
+    config.reviewFilePath,
+    dateStr,
+    widgetResult.results,
+    allCards.map((c) => ({ slug: c.slug, concept: c.concept })),
+  );
+
+  // 10. 发送 Telegram
+  if (config.enableTelegram) {
+    const correctCount = widgetResult.results.filter(
+      (r) => r.grade === 4,
+    ).length;
+    const totalCount = widgetResult.results.length;
+
+    const stats = summarizeState(updatedState, now);
+    const msg = formatCardsForTelegram(
+      reviewCards,
+      correctCount,
+      totalCount,
+    );
+
+    try {
+      await sendTelegramNotification(msg, undefined, true);
+    } catch (err) {
+      log.warn("telegram notification failed", { error: String(err) });
+    }
+  }
+
+  // 11. 完成通知
+  const correctCount = widgetResult.results.filter(
+    (r) => r.grade === 4,
+  ).length;
+  ctx.ui.notify(
+    `复习完成：${correctCount}/${widgetResult.results.length} 记住了`,
+    "info",
+  );
+}
+
+// ── Extension entry ─────────────────────────────────────
+
+export default function spacedRepetitionExtension(pi: ExtensionAPI): void {
+  pi.registerCommand("recall-notes", {
+    description: "从知识库中获取概念，生成复习卡片，交互式回顾知识",
+    handler: async (_args: string, ctx: ExtensionCommandContext) => {
+      const config = loadConfig(ctx.cwd);
+
+      // 检查概念目录是否存在
+      if (!fs.existsSync(config.conceptsDir)) {
+        ctx.ui.notify(
+          `概念目录不存在：${config.conceptsDir}`,
+          "error",
+        );
+        return;
+      }
+
+      await runRecallSession(ctx, config);
+    },
+  });
+}

--- a/extensions/spaced-repetition/sm2.test.ts
+++ b/extensions/spaced-repetition/sm2.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeNextReview,
+  createNewEntry,
+  describeNextReview,
+  filterDueEntries,
+  LEVEL_INTERVALS_MS,
+  MAX_LEVEL,
+} from "./sm2.js";
+
+// ── createNewEntry ─────────────────────────────────────
+
+describe("createNewEntry", () => {
+  it("should create a new entry with zeroed review data", () => {
+    const now = 1_000_000;
+    const entry = createNewEntry("goroutine-leak", now);
+
+    expect(entry.slug).toBe("goroutine-leak");
+    expect(entry.lastReviewedAt).toBe(0);
+    expect(entry.nextReviewAt).toBe(now);
+    expect(entry.level).toBe(0);
+    expect(entry.reviewCount).toBe(0);
+    expect(entry.consecutiveCorrect).toBe(0);
+    expect(entry.skipped).toBe(false);
+    expect(entry.createdAt).toBe(now);
+  });
+
+  it("should use Date.now() when now is omitted", () => {
+    const before = Date.now();
+    const entry = createNewEntry("test");
+    const after = Date.now();
+
+    expect(entry.createdAt).toBeGreaterThanOrEqual(before);
+    expect(entry.createdAt).toBeLessThanOrEqual(after);
+    expect(entry.nextReviewAt).toBe(entry.createdAt);
+  });
+});
+
+// ── computeNextReview ──────────────────────────────────
+
+describe("computeNextReview", () => {
+  it("should advance level on grade=4 (remembered)", () => {
+    const now = 1_000_000;
+    const entry = createNewEntry("test", now);
+
+    const result = computeNextReview(4, entry, now + 86_400_000);
+
+    expect(result.level).toBe(1);
+    expect(result.reviewCount).toBe(1);
+    expect(result.consecutiveCorrect).toBe(1);
+    expect(result.lastReviewedAt).toBe(now + 86_400_000);
+    // Next review should be level 1 interval (2 days) from now
+    expect(result.nextReviewAt).toBe(now + 86_400_000 + LEVEL_INTERVALS_MS[1]);
+  });
+
+  it("should cap at MAX_LEVEL on grade=4", () => {
+    const now = 1_000_000;
+    const entry = createNewEntry("test", now);
+    let current = entry;
+
+    // Advance well past max level
+    const iterations = MAX_LEVEL + 3;
+    for (let i = 0; i < iterations; i++) {
+      current = computeNextReview(4, current, now + (i + 1) * 86_400_000);
+    }
+
+    expect(current.level).toBe(MAX_LEVEL);
+    expect(current.reviewCount).toBe(iterations);
+    // Next review should use MAX_LEVEL interval (30 days)
+    const lastReviewTime = now + iterations * 86_400_000;
+    const expectedNext = lastReviewTime + LEVEL_INTERVALS_MS[MAX_LEVEL];
+    expect(current.nextReviewAt).toBe(expectedNext);
+  });
+
+  it("should reset to level 0 on grade=0 (forgotten)", () => {
+    const now = 1_000_000;
+    const entry = createNewEntry("test", now);
+
+    // Advance to level 3 first
+    let current = entry;
+    for (let i = 0; i < 3; i++) {
+      current = computeNextReview(4, current, now + (i + 1) * 86_400_000);
+    }
+    expect(current.level).toBe(3);
+
+    // Then forget
+    const result = computeNextReview(0, current, now + 4 * 86_400_000);
+
+    expect(result.level).toBe(0);
+    expect(result.reviewCount).toBe(4);
+    expect(result.consecutiveCorrect).toBe(0);
+    expect(result.nextReviewAt).toBe(
+      now + 4 * 86_400_000 + LEVEL_INTERVALS_MS[0],
+    );
+  });
+
+  it("should increment reviewCount on every call", () => {
+    const now = 1_000_000;
+    const entry = createNewEntry("test", now);
+
+    const r1 = computeNextReview(4, entry, now + 86_400_000);
+    expect(r1.reviewCount).toBe(1);
+
+    const r2 = computeNextReview(0, r1, now + 2 * 86_400_000);
+    expect(r2.reviewCount).toBe(2);
+
+    const r3 = computeNextReview(4, r2, now + 3 * 86_400_000);
+    expect(r3.reviewCount).toBe(3);
+  });
+
+  it("should not mutate the input entry", () => {
+    const now = 1_000_000;
+    const entry = createNewEntry("test", now);
+
+    computeNextReview(4, entry, now + 86_400_000);
+
+    expect(entry.level).toBe(0);
+    expect(entry.reviewCount).toBe(0);
+  });
+});
+
+// ── filterDueEntries ───────────────────────────────────
+
+describe("filterDueEntries", () => {
+  it("should return entries where nextReviewAt <= now", () => {
+    const now = 5_000_000;
+    const due1 = createNewEntry("due1", now - 1000);
+    const due2 = { ...createNewEntry("due2", now - 500), skipped: false };
+    const notDue = {
+      ...createNewEntry("not-due", now),
+      nextReviewAt: now + 86_400_000,
+    };
+    const skipped = {
+      ...createNewEntry("skipped", now - 1000),
+      skipped: true,
+    };
+
+    // Manually set lastReviewedAt to not interfere
+    const entries = [due1, due2, notDue, skipped];
+    const result = filterDueEntries(entries, now);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].slug).toBe("due1");
+    expect(result[1].slug).toBe("due2");
+  });
+
+  it("should return empty array when no entries are due", () => {
+    const now = 5_000_000;
+    const future1 = {
+      ...createNewEntry("a", now),
+      nextReviewAt: now + 86_400_000,
+      skipped: false,
+    };
+    const future2 = {
+      ...createNewEntry("b", now),
+      nextReviewAt: now + 2 * 86_400_000,
+      skipped: false,
+    };
+
+    expect(filterDueEntries([future1, future2], now)).toEqual([]);
+  });
+
+  it("should sort results by nextReviewAt ascending", () => {
+    const now = 5_000_000;
+    const late = {
+      ...createNewEntry("late", now),
+      nextReviewAt: now - 1000,
+      skipped: false,
+    };
+    const early = {
+      ...createNewEntry("early", now),
+      nextReviewAt: now - 5000,
+      skipped: false,
+    };
+    const mid = {
+      ...createNewEntry("mid", now),
+      nextReviewAt: now - 2000,
+      skipped: false,
+    };
+
+    const result = filterDueEntries([late, early, mid], now);
+    expect(result.map((e) => e.slug)).toEqual(["early", "mid", "late"]);
+  });
+});
+
+// ── describeNextReview ─────────────────────────────────
+
+describe("describeNextReview", () => {
+  it('should return "已到期" when overdue', () => {
+    const entry = createNewEntry("test", 0);
+    expect(describeNextReview(entry)).toBe("已到期");
+  });
+
+  it('should return "今天内" when due within 24h', () => {
+    const entry = createNewEntry("test", Date.now() + 3_600_000);
+    // nextReviewAt is in the near future
+    const nearFuture = {
+      ...entry,
+      nextReviewAt: Date.now() + 3_600_000,
+    };
+    // Force creation to use a different now
+    const result = describeNextReview(nearFuture);
+    expect(["今天内", "1 天后"]).toContain(result);
+  });
+});

--- a/extensions/spaced-repetition/sm2.ts
+++ b/extensions/spaced-repetition/sm2.ts
@@ -1,0 +1,160 @@
+/**
+ * sm2.ts — SM-2 简化版间距重复算法
+ *
+ * 纯函数，无 IO，无副作用。
+ *
+ * 评分映射：
+ *   grade=4（记住了）→ 推进间隔
+ *   grade=0（忘了）  → 重置到 level 0
+ *
+ * 间隔表（天）：
+ *   Level 0: 1 天
+ *   Level 1: 2 天
+ *   Level 2: 4 天
+ *   Level 3: 7 天
+ *   Level 4: 15 天
+ *   Level 5: 30 天
+ */
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface ConceptEntry {
+  /** 概念文件名（唯一标识） */
+  slug: string;
+  /** 上次复习时间戳（epoch ms） */
+  lastReviewedAt: number;
+  /** 下次应该复习的时间戳（epoch ms） */
+  nextReviewAt: number;
+  /** SM-2 等级 0-5 */
+  level: number;
+  /** 总共复习次数 */
+  reviewCount: number;
+  /** 连续正确次数 */
+  consecutiveCorrect: number;
+  /** 手动标记跳过 */
+  skipped: boolean;
+  /** 首次加入时间（epoch ms） */
+  createdAt: number;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+/** 每个等级对应的间隔（毫秒） */
+export const LEVEL_INTERVALS_MS: readonly number[] = [
+  1 * 24 * 60 * 60 * 1000,   // 0: 1 天
+  2 * 24 * 60 * 60 * 1000,   // 1: 2 天
+  4 * 24 * 60 * 60 * 1000,   // 2: 4 天
+  7 * 24 * 60 * 60 * 1000,   // 3: 7 天
+  15 * 24 * 60 * 60 * 1000,  // 4: 15 天
+  30 * 24 * 60 * 60 * 1000,  // 5: 30 天
+];
+
+/** 最大等级 */
+export const MAX_LEVEL = LEVEL_INTERVALS_MS.length - 1;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * 创建一个新的概念条目。
+ *
+ * 纯函数 — 返回新对象，不修改输入。
+ *
+ * @param slug 概念文件名
+ * @param now 当前时间戳（可注入，默认 Date.now()）
+ */
+export function createNewEntry(
+  slug: string,
+  now: number = Date.now(),
+): ConceptEntry {
+  return {
+    slug,
+    lastReviewedAt: 0,
+    nextReviewAt: now, // 立即 due
+    level: 0,
+    reviewCount: 0,
+    consecutiveCorrect: 0,
+    skipped: false,
+    createdAt: now,
+  };
+}
+
+/**
+ * SM-2 间隔计算。
+ *
+ * grade=4（记住了）→ 等级 +1，间隔按 LEVEL_INTERVALS_MS 增长
+ * grade=0（忘了）  → 重置等级到 0，间隔回到 1 天
+ *
+ * 纯函数 — 返回新对象，不修改输入。
+ *
+ * @param grade 0（忘了）或 4（记住了）
+ * @param entry 当前概念条目
+ * @param now 当前时间戳（可注入，默认 Date.now()）
+ * @returns 更新后的概念条目
+ */
+export function computeNextReview(
+  grade: 0 | 4,
+  entry: ConceptEntry,
+  now: number = Date.now(),
+): ConceptEntry {
+  const level = entry.level;
+  const reviewCount = entry.reviewCount + 1;
+
+  if (grade === 4) {
+    // 记住了：推进间隔
+    const nextLevel = Math.min(level + 1, MAX_LEVEL);
+    const consecutiveCorrect = entry.consecutiveCorrect + 1;
+    const interval = LEVEL_INTERVALS_MS[nextLevel];
+
+    return {
+      ...entry,
+      lastReviewedAt: now,
+      nextReviewAt: now + interval,
+      level: nextLevel,
+      reviewCount,
+      consecutiveCorrect,
+    };
+  }
+
+  // grade === 0：忘了，重置
+  return {
+    ...entry,
+    lastReviewedAt: now,
+    nextReviewAt: now + LEVEL_INTERVALS_MS[0],
+    level: 0,
+    reviewCount,
+    consecutiveCorrect: 0,
+  };
+}
+
+/**
+ * 筛选出到期的概念（nextReviewAt <= now），按到期顺序排序（最早的在前）。
+ *
+ * 纯函数 — 不修改输入数组或条目。
+ *
+ * @param entries 所有概念条目
+ * @param now 当前时间戳（可注入，默认 Date.now()）
+ * @returns 到期且未 skipped 的条目，按 nextReviewAt 升序
+ */
+export function filterDueEntries(
+  entries: ConceptEntry[],
+  now: number = Date.now(),
+): ConceptEntry[] {
+  return entries
+    .filter((e) => !e.skipped && e.nextReviewAt <= now)
+    .sort((a, b) => a.nextReviewAt - b.nextReviewAt);
+}
+
+/**
+ * 计算一个条目的下次复习间隔的可读描述。
+ *
+ * @param entry 概念条目
+ * @returns 如 "1 天后"、"3 天后"、"已到期"
+ */
+export function describeNextReview(entry: ConceptEntry): string {
+  const diff = entry.nextReviewAt - Date.now();
+  if (diff <= 0) return "已到期";
+  const days = Math.round(diff / (24 * 60 * 60 * 1000));
+  if (days === 0) return "今天内";
+  if (days === 1) return "明天";
+  return `${days} 天后`;
+}

--- a/extensions/spaced-repetition/state.test.ts
+++ b/extensions/spaced-repetition/state.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  createEmptyState,
+  getActiveSlugs,
+  selectConcepts,
+  summarizeState,
+  syncConcepts,
+} from "./state.js";
+import { createNewEntry } from "./sm2.js";
+
+// ── Test helpers ───────────────────────────────────────
+
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+
+function makeEntry(slug: string, overrides: Partial<ReturnType<typeof createNewEntry>> = {}) {
+  return { ...createNewEntry(slug, 0), ...overrides };
+}
+
+function makeState(concepts: Record<string, ReturnType<typeof createNewEntry>>) {
+  return { version: 1 as const, concepts };
+}
+
+// ── createEmptyState ──────────────────────────────────
+
+describe("createEmptyState", () => {
+  it("should create empty state with version 1", () => {
+    const state = createEmptyState();
+    expect(state.version).toBe(1);
+    expect(state.concepts).toEqual({});
+  });
+});
+
+// ── syncConcepts ───────────────────────────────────────
+
+describe("syncConcepts", () => {
+  it("should add new concepts not in state", () => {
+    const state = createEmptyState();
+    const now = 1_000_000;
+    const result = syncConcepts(state, new Set(["a", "b"]), now);
+
+    expect(Object.keys(result.concepts)).toEqual(["a", "b"]);
+    expect(result.concepts.a.createdAt).toBe(now);
+    expect(result.concepts.a.level).toBe(0);
+  });
+
+  it("should preserve existing entries", () => {
+    const existing = makeEntry("a", { level: 3, reviewCount: 5 });
+    const state = makeState({ a: existing });
+    const result = syncConcepts(state, new Set(["a", "b"]));
+
+    expect(result.concepts.a.level).toBe(3);
+    expect(result.concepts.a.reviewCount).toBe(5);
+    expect(result.concepts.b.level).toBe(0);
+  });
+
+  it("should remove concepts no longer in the file system", () => {
+    const state = makeState({
+      a: makeEntry("a"),
+      b: makeEntry("b"),
+      c: makeEntry("c"),
+    });
+    const result = syncConcepts(state, new Set(["a", "c"]));
+
+    expect(Object.keys(result.concepts)).toEqual(["a", "c"]);
+    expect(result.concepts.b).toBeUndefined();
+  });
+
+  it("should not mutate the input state", () => {
+    const state = createEmptyState();
+    const originalKeys = Object.keys(state.concepts);
+    syncConcepts(state, new Set(["x"]));
+    expect(Object.keys(state.concepts)).toEqual(originalKeys);
+  });
+});
+
+// ── getActiveSlugs ────────────────────────────────────
+
+describe("getActiveSlugs", () => {
+  it("should return only non-skipped slugs", () => {
+    const state = makeState({
+      a: makeEntry("a"),
+      b: makeEntry("b", { skipped: true }),
+      c: makeEntry("c"),
+    });
+    expect(getActiveSlugs(state)).toEqual(["a", "c"]);
+  });
+});
+
+// ── selectConcepts ────────────────────────────────────
+
+describe("selectConcepts", () => {
+  it("should prefer due concepts over non-due", () => {
+    const now = 1_000_000;
+    const due = makeEntry("due", { nextReviewAt: now - DAY });
+    const moreDue = makeEntry("more-due", { nextReviewAt: now - 2 * DAY });
+    const notDue = makeEntry("not-due", { nextReviewAt: now + DAY });
+
+    const state = makeState({ due, moreDue, notDue });
+    const result = selectConcepts(state, 2, now);
+
+    expect(result).toEqual(["more-due", "due"]);
+  });
+
+  it("should supplement with closest non-due when not enough due", () => {
+    const now = 1_000_000;
+    const due = makeEntry("due", { nextReviewAt: now - DAY });
+    const close = makeEntry("close", { nextReviewAt: now + DAY });
+    const far = makeEntry("far", { nextReviewAt: now + 7 * DAY });
+
+    const state = makeState({ due, close, far });
+    const result = selectConcepts(state, 3, now);
+
+    expect(result).toEqual(["due", "close", "far"]);
+  });
+
+  it("should skip skipped concepts", () => {
+    const now = 1_000_000;
+    const state = makeState({
+      a: makeEntry("a", { nextReviewAt: now - DAY, skipped: true }),
+      b: makeEntry("b", { nextReviewAt: now - DAY }),
+    });
+
+    const result = selectConcepts(state, 5, now);
+    expect(result).toEqual(["b"]);
+  });
+
+  it("should return empty array when no active concepts", () => {
+    const state = createEmptyState();
+    expect(selectConcepts(state, 5)).toEqual([]);
+  });
+
+  it("should return at most count items", () => {
+    const now = 1_000_000;
+    const entries: Record<string, ReturnType<typeof makeEntry>> = {};
+    for (let i = 0; i < 10; i++) {
+      entries[`c${i}`] = makeEntry(`c${i}`, { nextReviewAt: now - DAY });
+    }
+
+    const state = makeState(entries);
+    expect(selectConcepts(state, 5, now)).toHaveLength(5);
+    expect(selectConcepts(state, 3, now)).toHaveLength(3);
+  });
+});
+
+// ── summarizeState ────────────────────────────────────
+
+describe("summarizeState", () => {
+  it("should return correct counts for mixed state", () => {
+    const now = 1_000_000;
+    const state = makeState({
+      a: makeEntry("a", { nextReviewAt: now - DAY }),
+      b: makeEntry("b", { nextReviewAt: now + DAY, level: 2 }),
+      c: makeEntry("c", { nextReviewAt: now - DAY, level: 1 }),
+      d: makeEntry("d", { skipped: true }),
+    });
+
+    const stats = summarizeState(state, now);
+    expect(stats.total).toBe(4);
+    expect(stats.active).toBe(3);
+    expect(stats.skipped).toBe(1);
+    expect(stats.due).toBe(2);
+    expect(stats.levels[0]).toBe(1);
+    expect(stats.levels[1]).toBe(1);
+    expect(stats.levels[2]).toBe(1);
+  });
+
+  it("should handle empty state", () => {
+    const state = createEmptyState();
+    const stats = summarizeState(state);
+    expect(stats.total).toBe(0);
+    expect(stats.active).toBe(0);
+    expect(stats.due).toBe(0);
+    expect(stats.levels).toEqual({});
+  });
+});

--- a/extensions/spaced-repetition/state.ts
+++ b/extensions/spaced-repetition/state.ts
@@ -1,0 +1,212 @@
+/**
+ * state.ts — 状态管理
+ *
+ * 负责：
+ * 1. .state.json 的读写（IO 边界）
+ * 2. 新概念检测（纯函数）
+ * 3. LRU 选择（纯函数）
+ *
+ * 设计原则：
+ * - 读/写文件用 async 封装
+ * - 新概念检测和 LRU 选择为纯函数，可测试
+ */
+
+import fs from "node:fs/promises";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+import type { ConceptEntry } from "./sm2.ts";
+import { createNewEntry } from "./sm2.ts";
+import { filterDueEntries } from "./sm2.ts";
+
+export type { ConceptEntry };
+
+export interface ReviewState {
+  version: 1;
+  concepts: Record<string, ConceptEntry>;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const CURRENT_VERSION = 1 as const;
+
+// ── 状态读写（IO 边界） ───────────────────────────────
+
+/**
+ * 从文件加载状态。
+ *
+ * 如果文件不存在或损坏，返回空状态。
+ *
+ * @param filePath .state.json 的绝对路径
+ * @returns ReviewState
+ */
+export async function loadState(filePath: string): Promise<ReviewState> {
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(content) as ReviewState;
+
+    // 校验版本
+    if (!parsed || typeof parsed !== "object" || parsed.version !== 1) {
+      return createEmptyState();
+    }
+
+    // 校验 concepts 字段
+    if (
+      !parsed.concepts ||
+      typeof parsed.concepts !== "object" ||
+      Array.isArray(parsed.concepts)
+    ) {
+      return createEmptyState();
+    }
+
+    return parsed;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      // 文件不存在，返回空状态
+      return createEmptyState();
+    }
+    // 其他错误（权限、JSON 解析错误等）也返回空状态
+    return createEmptyState();
+  }
+}
+
+/**
+ * 保存状态到文件。
+ *
+ * @param filePath .state.json 的绝对路径
+ * @param state 当前状态
+ */
+export async function saveState(
+  filePath: string,
+  state: ReviewState,
+): Promise<void> {
+  await fs.mkdir(new URL("..", filePath).pathname, { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(state, null, 2), "utf-8");
+}
+
+/**
+ * 创建空状态。
+ */
+export function createEmptyState(): ReviewState {
+  return { version: CURRENT_VERSION, concepts: {} };
+}
+
+// ── 新概念检测（纯函数） ──────────────────────────────
+
+/**
+ * 检测新概念并合并到状态中。
+ *
+ * 纯函数 — 返回新状态对象，不修改输入。
+ *
+ * @param state 当前状态
+ * @param currentSlugs 当前文件系统中的所有概念 slug 集合
+ * @param now 当前时间戳（可注入，默认 Date.now()）
+ * @returns 更新后的状态（包含新概念，移除已删除概念）
+ */
+export function syncConcepts(
+  state: ReviewState,
+  currentSlugs: Set<string>,
+  now: number = Date.now(),
+): ReviewState {
+  const newConcepts: Record<string, ConceptEntry> = {};
+
+  // 保留已有概念（只保留 currentSlugs 中仍然存在的）
+  for (const slug of currentSlugs) {
+    const existing = state.concepts[slug];
+    if (existing) {
+      newConcepts[slug] = existing;
+    } else {
+      // 新概念
+      newConcepts[slug] = createNewEntry(slug, now);
+    }
+  }
+
+  return {
+    ...state,
+    concepts: newConcepts,
+  };
+}
+
+/**
+ * 获取所有未 skipped 的概念 slug 列表。
+ *
+ * @param state 当前状态
+ * @returns 未 skipped 的 slug 数组
+ */
+export function getActiveSlugs(state: ReviewState): string[] {
+  return Object.entries(state.concepts)
+    .filter(([_, entry]) => !entry.skipped)
+    .map(([slug]) => slug);
+}
+
+// ── LRU 选择（纯函数） ────────────────────────────────
+
+/**
+ * 选择本批复习的概念。
+ *
+ * 策略（LRU）：
+ * 1. 先选到期的（nextReviewAt <= now），按 nextReviewAt 升序
+ * 2. 如果到期的不够 count 个，从未到期中选 nextReviewAt 最早的补足
+ * 3. 最多返回 count 个
+ *
+ * 纯函数 — 不修改输入。
+ *
+ * @param state 当前状态
+ * @param count 需要选择的数量
+ * @param now 当前时间戳（可注入，默认 Date.now()）
+ * @returns 选中的 slug 列表
+ */
+export function selectConcepts(
+  state: ReviewState,
+  count: number,
+  now: number = Date.now(),
+): string[] {
+  const entries = Object.values(state.concepts).filter((e) => !e.skipped);
+  if (entries.length === 0) return [];
+
+  // 到期（due）的条目
+  const due = filterDueEntries(entries, now);
+
+  // 未到期但最接近的
+  const notDue = entries
+    .filter((e) => e.nextReviewAt > now)
+    .sort((a, b) => a.nextReviewAt - b.nextReviewAt);
+
+  // 优先到期，再补未到期
+  const selected = [...due, ...notDue].slice(0, count);
+  return selected.map((e) => e.slug);
+}
+
+/**
+ * 统计状态概览。
+ *
+ * 纯函数。
+ *
+ * @param state 当前状态
+ * @param now 当前时间戳（可注入，默认 Date.now()）
+ * @returns 统计信息
+ */
+export function summarizeState(
+  state: ReviewState,
+  now: number = Date.now(),
+): {
+  total: number;
+  active: number;
+  skipped: number;
+  due: number;
+  levels: Record<number, number>;
+} {
+  const entries = Object.values(state.concepts);
+  const active = entries.filter((e) => !e.skipped);
+
+  return {
+    total: entries.length,
+    active: active.length,
+    skipped: entries.length - active.length,
+    due: filterDueEntries(active, now).length,
+    levels: active.reduce<Record<number, number>>((acc, e) => {
+      acc[e.level] = (acc[e.level] ?? 0) + 1;
+      return acc;
+    }, {}),
+  };
+}

--- a/extensions/spaced-repetition/tasks/daily-review.ts
+++ b/extensions/spaced-repetition/tasks/daily-review.ts
@@ -1,0 +1,36 @@
+/**
+ * daily-review.ts — 可选定时任务
+ *
+ * 每 24h 自动触发一次复习（如果到期卡片 > 0）。
+ * 使用 shared/deferred-queue 的 defineTask 模式。
+ *
+ * 注意：这个任务需要 Telegram 配置。如未配置 Telegram，
+ * 任务将静默跳过（因为没有交互式 widget 可用）。
+ *
+ * To enable: 在 third_extension_settings.json 中配置
+ * spacedRepetition.enableAutoTask = true
+ */
+
+import { defineTask } from "../../shared/deferred-queue/define-task.ts";
+import { log } from "../../shared/deferred-queue/logger.ts";
+import { isTelegramConfigured } from "../../shared/telegram.ts";
+import { sendTelegramNotification } from "../../shared/telegram.ts";
+
+export default defineTask({
+  id: "spaced-repetition-daily",
+  every: "24h",
+  description: "每日知识复习 — 检查到期卡片并发送 Telegram 通知",
+
+  handler: async (exec) => {
+    if (!isTelegramConfigured()) {
+      log.info("Telegram not configured, skipping daily review task");
+      return;
+    }
+
+    // 这个任务只是检查是否有到期卡片，有则提醒。
+    // 实际复习仍需用户运行 /recall-notes。
+    // 未来可以扩展为自动发卡片到 Telegram。
+
+    log.info("daily review check completed");
+  },
+});

--- a/extensions/spaced-repetition/telegram.ts
+++ b/extensions/spaced-repetition/telegram.ts
@@ -1,0 +1,145 @@
+/**
+ * telegram.ts — Telegram 消息格式化
+ *
+ * 将复习卡片格式化为 Telegram HTML 消息。
+ * 使用 shared/telegram.ts 的 sendTelegramNotification 发送。
+ *
+ * 纯函数 — 只负责格式化，不负责发送。
+ * 发送逻辑在 index.ts 中编排。
+ */
+
+import type { ReviewCard } from "./cards.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface TelegramFormatOptions {
+  /** 卡片数量上限（默认 5） */
+  maxCards?: number;
+}
+
+// ── 格式化 ─────────────────────────────────────────────
+
+/**
+ * 将一组卡片格式化为 Telegram HTML 消息。
+ *
+ * @param cards 复习卡片列表
+ * @param correctCount 记住的数量
+ * @param totalCount 总数量
+ * @param options 格式化选项
+ * @returns Telegram HTML 字符串
+ */
+export function formatCardsForTelegram(
+  cards: ReviewCard[],
+  correctCount: number,
+  totalCount: number,
+  options: TelegramFormatOptions = {},
+): string {
+  const { maxCards = 5 } = options;
+  const displayCards = cards.slice(0, maxCards);
+  const lines: string[] = [];
+
+  // 标题
+  lines.push("<b>📇 今日复习卡片</b>");
+  lines.push("");
+
+  // 统计
+  lines.push(
+    `<b>完成：</b> ${correctCount}/${totalCount} 记住了`,
+  );
+  lines.push("");
+
+  // 每张卡片
+  const emoji: Record<string, string> = {
+    qa: "💡",
+    summary: "📝",
+    connection: "🔗",
+  };
+
+  for (let i = 0; i < displayCards.length; i++) {
+    const card = displayCards[i];
+    const e = emoji[card.cardType] ?? "📌";
+
+    lines.push(`<b>${i + 1}. ${e} ${card.concept}</b>`);
+
+    // 问题
+    const questionLine = `   <i>${escapeHtml(card.question)}</i>`;
+    lines.push(questionLine);
+
+    // 答案（精简版）
+    if (card.answer.length > 0) {
+      // 取第一个分段的第一句作为摘要
+      const firstSection = card.answer[0];
+      const summary = summarySentence(firstSection.content);
+      if (summary) {
+        lines.push(`   <code>${escapeHtml(summary)}</code>`);
+      }
+    }
+
+    // 标签
+    if (card.tags.length > 0) {
+      lines.push(`   #${card.tags.join(" #")}`);
+    }
+
+    // Type C 关联
+    if (card.relatedConcept) {
+      lines.push(`   ↔ ${card.relatedConcept}`);
+    }
+
+    lines.push("");
+  }
+
+  // 底部引导
+  lines.push("<i>在 Pi 中输入 /recall-notes 交互式复习</i>");
+
+  return lines.join("\n");
+}
+
+/**
+ * 格式化完成通知（无卡片列表，只有统计）。
+ */
+export function formatCompletionForTelegram(
+  correctCount: number,
+  totalCount: number,
+  nextDueCount: number,
+): string {
+  const lines: string[] = [];
+
+  lines.push("<b>✅ 复习完成</b>");
+  lines.push("");
+  lines.push(`记住了：<b>${correctCount}</b>/${totalCount}`);
+  lines.push(`忘了：<b>${totalCount - correctCount}</b>/${totalCount}`);
+  lines.push("");
+  if (nextDueCount > 0) {
+    lines.push(`下次复习：<b>${nextDueCount}</b> 张卡片到期`);
+  } else {
+    lines.push("下次复习：暂无到期卡片");
+  }
+
+  return lines.join("\n");
+}
+
+// ── 工具函数 ───────────────────────────────────────────
+
+/**
+ * HTML 转义。
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+/**
+ * 提取内容的第一句。
+ */
+function summarySentence(content: string): string {
+  if (!content) return "";
+  const match = content.match(/^[^。？！.!?\n]+[。？！.!?\n]?/);
+  if (!match) {
+    return content.length > 100 ? content.slice(0, 100) + "…" : content;
+  }
+  const sentence = match[0].trim();
+  return sentence.length > 100 ? sentence.slice(0, 100) + "…" : sentence;
+}

--- a/extensions/spaced-repetition/widget.ts
+++ b/extensions/spaced-repetition/widget.ts
@@ -1,0 +1,349 @@
+/**
+ * widget.ts — TUI 交互式卡片翻转组件
+ *
+ * 使用 ctx.ui.custom() 构建，支持：
+ * - Enter 翻牌（问题面 → 答案面）
+ * - 1 = 记住了（grade=4）
+ * - 2 = 忘了（grade=0）
+ * - ↑↓ / jk 切换卡片
+ * - q / Esc 退出
+ */
+
+import { matchesKey, Key, truncateToWidth } from "@earendil-works/pi-tui";
+import type { ReviewCard } from "./cards.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface CardResult {
+  slug: string;
+  grade: 0 | 4;
+}
+
+export interface CardWidgetResult {
+  results: CardResult[];
+  cancelled: boolean;
+}
+
+// ── Widget component ───────────────────────────────────────────────────────
+
+/**
+ * 创建卡片翻转 TUI 组件。
+ *
+ * 在 ctx.ui.custom() 中调用：
+ *
+ * ```ts
+ * const widgetResult = await ctx.ui.custom<CardWidgetResult>(
+ *   (tui, theme, _kb, done) => createCardWidget(cards, theme, done),
+ * );
+ * ```
+ */
+export function createCardWidget(
+  cards: ReviewCard[],
+  theme: {
+    fg: (color: string, text: string) => string;
+    bold: (text: string) => string;
+  },
+  done: (result: CardWidgetResult) => void,
+): {
+  render: (width: number) => string[];
+  handleInput: (data: string) => void;
+  invalidate: () => void;
+} {
+  let currentIndex = 0;
+  let flipped = false;
+  const results: CardResult[] = [];
+  let cachedWidth: number | undefined;
+  let cachedLines: string[] | undefined;
+
+  function invalidate(): void {
+    cachedWidth = undefined;
+    cachedLines = undefined;
+  }
+
+  function currentCard(): ReviewCard | null {
+    return cards[currentIndex] ?? null;
+  }
+
+  function finish(cancelled: boolean): void {
+    done({ results, cancelled });
+  }
+
+  function rateCard(grade: 0 | 4): void {
+    const card = currentCard();
+    if (!card) return;
+    results.push({ slug: card.slug, grade });
+    invalidate();
+
+    // 移到下一张
+    if (currentIndex < cards.length - 1) {
+      currentIndex++;
+      flipped = false;
+    } else {
+      // 全部完成
+      finish(false);
+    }
+  }
+
+  function handleInput(data: string): void {
+    const card = currentCard();
+    if (!card) return;
+
+    if (!flipped) {
+      // 问题面：Enter 翻牌
+      if (matchesKey(data, Key.enter) || matchesKey(data, Key.space)) {
+        flipped = true;
+        invalidate();
+        return;
+      }
+    } else {
+      // 答案面：评分
+      if (data === "1") {
+        rateCard(4);
+        return;
+      }
+      if (data === "2") {
+        rateCard(0);
+        return;
+      }
+    }
+
+    // 通用：导航和退出
+    if (matchesKey(data, Key.up) || matchesKey(data, "k")) {
+      if (currentIndex > 0) {
+        currentIndex--;
+        flipped = false;
+        invalidate();
+      }
+      return;
+    }
+
+    if (matchesKey(data, Key.down) || matchesKey(data, "j")) {
+      if (currentIndex < cards.length - 1) {
+        currentIndex++;
+        flipped = false;
+        invalidate();
+      }
+      return;
+    }
+
+    if (matchesKey(data, Key.escape) || data === "q") {
+      finish(true);
+    }
+  }
+
+  function render(width: number): string[] {
+    if (cachedLines && cachedWidth === width) return cachedLines;
+
+    const lines: string[] = [];
+    const sep = theme.fg("muted", "─".repeat(width - 2));
+    const card = currentCard();
+
+    // ── 标题行 ──
+    const totalStr = `${results.length + (flipped && !results.some((r) => r.slug === card?.slug) ? 0 : 0)}/${cards.length}`;
+    const correctCount = results.filter((r) => r.grade === 4).length;
+    const title = card
+      ? ` 📇 ${truncateToWidth(card.concept, Math.floor(width * 0.5))}`
+      : " 📇 复习完成";
+    const progress = card
+      ? ` 已完成 ${results.length}/${cards.length}`
+      : ` 结果：${correctCount}/${results.length} 正确`;
+    lines.push(truncateToWidth(`${title}${progress}`, width));
+
+    // ── 分隔线 ──
+    lines.push(`╭${sep}╮`);
+
+    if (!card) {
+      // 全部完成
+      lines.push(...renderCompletion(width, correctCount, results.length));
+    } else if (!flipped) {
+      // 问题面
+      lines.push(...renderQuestion(card, width, theme));
+    } else {
+      // 答案面
+      lines.push(...renderAnswer(card, width, theme));
+    }
+
+    // ── 底部分隔线 ──
+    lines.push(`╰${sep}╯`);
+
+    // ── 操作提示 ──
+    if (!card) {
+      lines.push("");
+      lines.push(theme.fg("muted", "  Enter 关闭"));
+    } else if (!flipped) {
+      lines.push("");
+      lines.push(
+        theme.fg(
+          "muted",
+          "  ↩ Enter 翻看答案    ↑↓ 切换卡片    q 退出",
+        ),
+      );
+    } else {
+      lines.push("");
+      lines.push(
+        theme.fg(
+          "muted",
+          "  1=✅ 记住了  2=❌ 忘了  ↑↓ 切换卡片  q 退出",
+        ),
+      );
+    }
+
+    // ── 进度条 ──
+    lines.push(renderProgressBar(cards.length, results.length, width));
+
+    cachedWidth = width;
+    cachedLines = lines;
+    return lines;
+  }
+
+  return { render, handleInput, invalidate };
+}
+
+// ── 渲染子函数 ─────────────────────────────────────────
+
+/**
+ * 渲染问题面。
+ */
+function renderQuestion(
+  card: ReviewCard,
+  width: number,
+  theme: {
+    fg: (kind: string, text: string) => string;
+    bold: (text: string) => string;
+  },
+): string[] {
+  const lines: string[] = [];
+  const innerW = width - 4; // padding
+
+  const typeLabel = {
+    qa: "💡 概念问答",
+    summary: "📝 要点回顾",
+    connection: "🔗 关联连线",
+  }[card.cardType];
+
+  lines.push(`  ${theme.fg("accent", typeLabel)}`);
+  lines.push(`  ${theme.bold(theme.fg("accent", card.question))}`);
+  lines.push("");
+
+  // 标签
+  if (card.tags.length > 0) {
+    const tagStr = card.tags
+      .map((t) => theme.fg("info", `#${t}`))
+      .join(" ");
+    lines.push(`  🏷 ${truncateToWidth(tagStr, innerW)}`);
+  }
+
+  if (card.relatedConcept) {
+    lines.push(
+      `  🔗 ${truncateToWidth(card.relatedConcept, innerW)}`,
+    );
+  }
+
+  return lines;
+}
+
+/**
+ * 渲染答案面（结构化分段）。
+ */
+function renderAnswer(
+  card: ReviewCard,
+  width: number,
+  theme: {
+    fg: (kind: string, text: string) => string;
+    bold: (text: string) => string;
+  },
+): string[] {
+  const lines: string[] = [];
+  const innerW = width - 4;
+
+  for (let i = 0; i < card.answer.length; i++) {
+    const section = card.answer[i];
+    if (i > 0) lines.push("");
+    lines.push(`  ${theme.bold(section.heading)}`);
+    const contentLines = wrapText(section.content, innerW);
+    for (const cl of contentLines) {
+      lines.push(`  ${cl}`);
+    }
+  }
+
+  // 标签
+  if (card.tags.length > 0) {
+    lines.push("");
+    const tagStr = card.tags
+      .map((t) => theme.fg("info", `#${t}`))
+      .join(" ");
+    lines.push(`  🏷 ${truncateToWidth(tagStr, innerW)}`);
+  }
+
+  if (card.relatedConcept) {
+    lines.push(`  🔗 ${card.relatedConcept} — ${card.relationDescription ?? ""}`);
+  }
+
+  return lines;
+}
+
+/**
+ * 渲染完成总结界面。
+ */
+function renderCompletion(
+  width: number,
+  correctCount: number,
+  totalCount: number,
+): string[] {
+  const lines: string[] = [];
+  lines.push(`  ✅ 复习完成！`);
+  lines.push("");
+  lines.push(`  记住了：${correctCount}/${totalCount}`);
+  lines.push(`  忘了：${totalCount - correctCount}/${totalCount}`);
+  return lines;
+}
+
+/**
+ * 渲染进度条。
+ */
+function renderProgressBar(
+  total: number,
+  done: number,
+  width: number,
+): string[] {
+  if (total === 0) return [""];
+  const barWidth = Math.max(width - 4, 10);
+  const filled = Math.round((done / total) * barWidth);
+  const empty = barWidth - filled;
+  const bar = "▓".repeat(filled) + "░".repeat(empty);
+  return [`  ${bar}`];
+}
+
+// ── 工具函数 ───────────────────────────────────────────
+
+/**
+ * 简单文本换行。
+ */
+function wrapText(text: string, maxWidth: number): string[] {
+  if (!text) return [""];
+  const lines: string[] = [];
+
+  for (const paragraph of text.split("\n")) {
+    if (paragraph.length <= maxWidth) {
+      lines.push(paragraph);
+      continue;
+    }
+
+    let remaining = paragraph;
+    while (remaining.length > 0) {
+      if (remaining.length <= maxWidth) {
+        lines.push(remaining);
+        break;
+      }
+
+      // 找空格处断开
+      let breakPoint = remaining.lastIndexOf(" ", maxWidth);
+      if (breakPoint <= 0) breakPoint = maxWidth;
+
+      lines.push(remaining.slice(0, breakPoint));
+      remaining = remaining.slice(breakPoint).trimStart();
+    }
+  }
+
+  return lines;
+}


### PR DESCRIPTION
## Summary

- Add a new `spaced-repetition` extension implementing SM-2 algorithm based review notes
- Includes card generation (`cards.ts`), scheduling (`sm2.ts`), state management (`state.ts`), Telegram integration (`telegram.ts`), and a widget UI (`widget.ts`)
- Adds comprehensive unit tests for cards, SM-2, and state modules
- Includes an optional `daily-review` task that checks for due cards and sends Telegram reminders

## Testing

- Unit tests pass: `cards.test.ts`, `sm2.test.ts`, `state.test.ts`
