### PR TITLE
feat(scheduled-tasks): archive Raindrop bookmarks to per-year markdown

### DIFF
--- a/extensions/scheduled-tasks/tasks/knowledge-wiki-daily.test.ts
+++ b/extensions/scheduled-tasks/tasks/knowledge-wiki-daily.test.ts
@@ -12,6 +12,7 @@ import {
 // Mock Telegram to prevent actual network calls during shell function tests.
 vi.mock("../../shared/telegram.ts", () => ({
   sendTelegramNotification: vi.fn(() => Promise.resolve()),
+  escapeHtml: (text: string) => text,
 }));
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/extensions/scheduled-tasks/tasks/knowledge-wiki-daily.ts
+++ b/extensions/scheduled-tasks/tasks/knowledge-wiki-daily.ts
@@ -20,7 +20,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineTask } from "../../shared/deferred-queue/define-task.ts";
 import { log } from "../../shared/deferred-queue/logger.ts";
-import { sendTelegramNotification } from "../../shared/telegram.ts";
+import { escapeHtml, sendTelegramNotification } from "../../shared/telegram.ts";
 
 // ── Paths ──────────────────────────────────────────────────────────────────
 
@@ -262,7 +262,7 @@ function buildTelegramSuccessMessage(
     lines.push(`<b>📄 已创建 / 更新（${summaries.length} 个 summary）</b>`);
     const displayed = summaries.slice(0, maxFiles);
     for (const s of displayed) {
-      lines.push(`  <code>${escapeTelegramHtml(s)}</code>`);
+      lines.push(`  <code>${escapeHtml(s)}</code>`);
     }
     if (summaries.length > maxFiles) {
       lines.push(`  <code>... 还有 ${summaries.length - maxFiles} 个</code>`);
@@ -275,7 +275,7 @@ function buildTelegramSuccessMessage(
     lines.push(`<b>📄 源文件（${staleFiles.length} 个 stale 文件）</b>`);
     const displayed = staleFiles.slice(0, maxFiles);
     for (const f of displayed) {
-      lines.push(`  <code>${escapeTelegramHtml(f)}</code>`);
+      lines.push(`  <code>${escapeHtml(f)}</code>`);
     }
     if (staleFiles.length > maxFiles) {
       lines.push(`  <code>... 还有 ${staleFiles.length - maxFiles} 个</code>`);
@@ -301,7 +301,7 @@ function buildTelegramFailureMessage(
   const lines: string[] = [
     `❌ 知识库维护失败 — ${step}`,
     "",
-    `错误：${escapeTelegramHtml(error)}`,
+    `错误：${escapeHtml(error)}`,
   ];
 
   if (extra?.exitCode !== undefined) {
@@ -309,21 +309,10 @@ function buildTelegramFailureMessage(
   }
   if (extra?.stderr) {
     const snippet = extra.stderr.slice(0, 500);
-    lines.push(`stderr：${escapeTelegramHtml(snippet)}`);
+    lines.push(`stderr：${escapeHtml(snippet)}`);
   }
 
   return lines.join("\n");
-}
-
-/**
- * Escape text for Telegram HTML (only & < > ").
- */
-function escapeTelegramHtml(text: string): string {
-  return text
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
 }
 
 // ── Batch subagent processing ────────────────────────────────────────────

--- a/extensions/scheduled-tasks/tasks/raindrop-bookmarks.test.ts
+++ b/extensions/scheduled-tasks/tasks/raindrop-bookmarks.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from "vitest";
+import {
+  type BookmarkItem,
+  buildArchiveEntry,
+  renderArchiveEntry,
+  selectNewArchiveItems,
+} from "./raindrop-bookmarks.ts";
+
+// ── Fixtures ──────────────────────────────────────────
+
+const sampleItem = (overrides: Partial<BookmarkItem> = {}): BookmarkItem => ({
+  title: "An Article",
+  link: "https://example.com/a",
+  domain: "example.com",
+  created: "2026-07-31T10:00:00.000Z",
+  tags: ["go", "testing"],
+  excerpt: "Some excerpt text",
+  ...overrides,
+});
+
+// ── buildArchiveEntry ─────────────────────────────────
+
+describe("buildArchiveEntry", () => {
+  it("creates the file title and a dated section on first run", () => {
+    const items = [
+      sampleItem({ title: "First", link: "https://a.example.com" }),
+      sampleItem({ title: "Second", link: "https://b.example.com" }),
+    ];
+
+    const out = buildArchiveEntry("2026-07-31", items, "");
+
+    expect(out).toContain("# Raindrop 书签档案（2026）");
+    expect(out).toContain("## 2026-07-31");
+    expect(out).toContain("1. **First**");
+    expect(out).toContain("2. **Second**");
+    expect(out).toContain("🔗 https://a.example.com");
+    expect(out).toContain("🔗 https://b.example.com");
+    expect(out).toContain("📍 example.com 🏷️ go, testing");
+    expect(out).toContain("💬 Some excerpt text");
+  });
+
+  it("does not repeat the file title on subsequent appends", () => {
+    const existing = [
+      "# Raindrop 书签档案（2026）",
+      "",
+      "## 2026-07-30",
+      "",
+      "1. **Old**",
+      "🔗 https://old.example.com",
+      "📍 old.example.com",
+      "",
+    ].join("\n");
+
+    const out = buildArchiveEntry(
+      "2026-07-31",
+      [sampleItem({ title: "New", link: "https://new.example.com" })],
+      existing,
+    );
+
+    expect(out).not.toContain("# Raindrop 书签档案");
+    expect(out).toContain("## 2026-07-31");
+    expect(out).toContain("New");
+  });
+
+  it("dedupes by link: only appends items whose link is not archived yet", () => {
+    const existing = [
+      "## 2026-07-30",
+      "",
+      "1. **Old**",
+      "🔗 https://a.example.com",
+      "📍 example.com",
+      "",
+    ].join("\n");
+
+    const items = [
+      sampleItem({ title: "Dup", link: "https://a.example.com" }),
+      sampleItem({ title: "Fresh", link: "https://c.example.com" }),
+    ];
+
+    const out = buildArchiveEntry("2026-07-31", items, existing);
+
+    expect(out).not.toContain("Dup");
+    expect(out).toContain("Fresh");
+    expect(out).toContain("🔗 https://c.example.com");
+  });
+
+  it("returns empty string when everything is already archived", () => {
+    const existing = [
+      "## 2026-07-30",
+      "",
+      "1. **Old**",
+      "🔗 https://a.example.com",
+      "📍 example.com",
+      "",
+    ].join("\n");
+
+    expect(
+      buildArchiveEntry(
+        "2026-07-31",
+        [sampleItem({ link: "https://a.example.com" })],
+        existing,
+      ),
+    ).toBe("");
+  });
+
+  it("falls back to title as the dedupe key when the link is empty", () => {
+    const out = buildArchiveEntry(
+      "2026-07-31",
+      [sampleItem({ link: "", title: "NoLink" })],
+      "",
+    );
+
+    expect(out).toContain("🔗 NoLink");
+  });
+
+  it("skips items with neither link nor title", () => {
+    const out = buildArchiveEntry(
+      "2026-07-31",
+      [sampleItem({ link: "", title: "" })],
+      "",
+    );
+
+    expect(out).toBe("");
+  });
+
+  it("truncates the excerpt to 200 chars in the archive", () => {
+    const out = buildArchiveEntry(
+      "2026-07-31",
+      [sampleItem({ excerpt: "x".repeat(500) })],
+      "",
+    );
+
+    expect(out).toContain(`💬 ${"x".repeat(200)}`);
+    expect(out).not.toContain("x".repeat(201));
+  });
+
+  it("keeps the excerpt on a single line so excerpt text cannot forge dedupe keys", () => {
+    const out = buildArchiveEntry(
+      "2026-07-31",
+      [
+        sampleItem({
+          excerpt: "first line\n🔗 https://example.com/a\nlast line",
+        }),
+      ],
+      "",
+    );
+
+    // Exactly one 🔗 line: the real key line, not the excerpt content
+    const linkLines = out.match(/^🔗 .+$/gm) ?? [];
+    expect(linkLines).toHaveLength(1);
+    expect(linkLines[0]).toBe("🔗 https://example.com/a");
+    expect(out).toContain("💬 first line 🔗 https://example.com/a last line");
+  });
+
+  it("collapses newlines in the title fallback key", () => {
+    const out = buildArchiveEntry(
+      "2026-07-31",
+      [sampleItem({ link: "", title: "Multi\nline" })],
+      "",
+    );
+
+    expect(out).toContain("🔗 Multi line");
+  });
+
+  it("dedupes against the previous year file when starting a new year", () => {
+    const prevYearContent = [
+      "# Raindrop 书签档案（2025）",
+      "",
+      "## 2025-12-31",
+      "",
+      "1. **Old**",
+      "🔗 https://a.example.com",
+      "📍 example.com",
+      "",
+    ].join("\n");
+
+    const out = buildArchiveEntry(
+      "2026-01-01",
+      [sampleItem({ title: "Dup", link: "https://a.example.com" })],
+      "", // current year file is still empty
+      prevYearContent,
+    );
+
+    expect(out).toBe("");
+  });
+
+  it("appends genuinely new items when only the previous year had keys", () => {
+    const prevYearContent = [
+      "## 2025-12-31",
+      "",
+      "1. **Old**",
+      "🔗 https://a.example.com",
+      "📍 example.com",
+      "",
+    ].join("\n");
+
+    const out = buildArchiveEntry(
+      "2026-01-01",
+      [
+        sampleItem({ link: "https://a.example.com" }),
+        sampleItem({ link: "https://b.example.com", title: "Fresh" }),
+      ],
+      "",
+      prevYearContent,
+    );
+
+    expect(out).toContain("# Raindrop 书签档案（2026）");
+    expect(out).not.toContain("An Article");
+    expect(out).not.toContain("https://a.example.com");
+    expect(out).toContain("🔗 https://b.example.com");
+    expect(out).toContain("**Fresh**");
+  });
+});
+
+// ── selectNewArchiveItems（纯决策）─────────────────────
+
+describe("selectNewArchiveItems", () => {
+  it("keeps only items whose key is not in the existing set", () => {
+    const items = [
+      sampleItem({ title: "Dup", link: "https://a.example.com" }),
+      sampleItem({ title: "Fresh", link: "https://b.example.com" }),
+    ];
+
+    const result = selectNewArchiveItems(
+      items,
+      new Set(["https://a.example.com"]),
+    );
+
+    expect(result).toEqual([items[1]]);
+  });
+
+  it("falls back to title as the key when the link is empty", () => {
+    const result = selectNewArchiveItems(
+      [sampleItem({ link: "", title: "NoLink" })],
+      new Set(["NoLink"]),
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("skips items with neither link nor title", () => {
+    const result = selectNewArchiveItems(
+      [sampleItem({ link: "", title: "" })],
+      new Set(),
+    );
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ── renderArchiveEntry（纯渲染）────────────────────────
+
+describe("renderArchiveEntry", () => {
+  it("writes the file title only when includeFileTitle is set", () => {
+    const item = sampleItem({ title: "First" });
+
+    const withTitle = renderArchiveEntry("2026-07-31", [item], true);
+    const withoutTitle = renderArchiveEntry("2026-07-31", [item], false);
+
+    expect(withTitle).toContain("# Raindrop 书签档案（2026）");
+    expect(withoutTitle).not.toContain("# Raindrop 书签档案");
+    expect(withoutTitle).toContain("## 2026-07-31");
+    expect(withoutTitle).toContain("1. **First**");
+  });
+});

--- a/extensions/scheduled-tasks/tasks/raindrop-bookmarks.ts
+++ b/extensions/scheduled-tasks/tasks/raindrop-bookmarks.ts
@@ -60,6 +60,23 @@ export function computeIncrement(
 // ── Pure core: format items as Markdown ─────────────────
 
 /**
+ * Collapse newlines in user-supplied text (excerpts, titles) so it can never
+ * spill into extra lines that could be misparsed as dedupe key lines.
+ */
+function normalizeSingleLine(text: string): string {
+  return text.replace(/\s*\n+\s*/g, " ").trim();
+}
+
+/** 条目体公共部分：excerpt 截断 + tags 后缀（Telegram 与档案共用）。 */
+function renderItemBody(item: BookmarkItem): { excerpt: string; tags: string } {
+  const excerpt = item.excerpt
+    ? `\n💬 ${normalizeSingleLine(item.excerpt).slice(0, 200)}`
+    : "";
+  const tags = item.tags.length > 0 ? ` 🏷️ ${item.tags.join(", ")}` : "";
+  return { excerpt, tags };
+}
+
+/**
  * Convert a list of bookmark items into reading-friendly Markdown.
  */
 export function formatIncrement(
@@ -74,8 +91,7 @@ export function formatIncrement(
 
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
-    const excerpt = item.excerpt ? `\n💬 ${item.excerpt.slice(0, 200)}` : "";
-    const tags = item.tags.length > 0 ? ` 🏷️ ${item.tags.join(", ")}` : "";
+    const { excerpt, tags } = renderItemBody(item);
 
     parts.push(
       `## ${i + 1}. **${item.title}**`,
@@ -88,6 +104,106 @@ export function formatIncrement(
   return parts.join("\n");
 }
 
+// ── Pure core: per-year archive entry ───────────────────
+
+/** Lines starting with this prefix carry the dedupe key (the bookmark URL). */
+const ARCHIVE_LINK_RE = /^🔗 (.+)$/gm;
+
+/** 从已有文件内容中提取已归档的 key（`🔗 <key>` 行）。 */
+function extractArchiveKeys(existingContent: string): Set<string> {
+  const keys = new Set<string>();
+  const linkRe = new RegExp(ARCHIVE_LINK_RE.source, "gm");
+  for (const match of existingContent.matchAll(linkRe)) {
+    keys.add(match[1]);
+  }
+  return keys;
+}
+
+/**
+ * Dedupe key for an archive entry: link, falling back to the title.
+ *
+ * Newlines are collapsed so the `🔗 <key>` line stays a single line and a
+ * later run can re-extract it verbatim via {@link ARCHIVE_LINK_RE}.
+ */
+function archiveKey(item: BookmarkItem): string {
+  return normalizeSingleLine(item.link || item.title);
+}
+
+/**
+ * 纯决策：过滤出尚未归档的条目。
+ *
+ * key = link（回退 title）；空 key 的条目跳过。输入是简单值集合，
+ * 不接触文件格式，独立可测。
+ */
+export function selectNewArchiveItems(
+  items: BookmarkItem[],
+  existingKeys: ReadonlySet<string>,
+): BookmarkItem[] {
+  return items.filter((item) => {
+    const key = archiveKey(item);
+    if (!key) return false;
+    return !existingKeys.has(key);
+  });
+}
+
+/**
+ * 纯渲染：把新条目渲染为追加文本。
+ *
+ * @param includeFileTitle - 首次建文件时写 `# ...` 标题（由编排方决定）。
+ */
+export function renderArchiveEntry(
+  date: string,
+  newItems: BookmarkItem[],
+  includeFileTitle: boolean,
+): string {
+  const parts: string[] = [];
+  if (includeFileTitle) {
+    parts.push(`# Raindrop 书签档案（${date.slice(0, 4)}）`, "");
+  }
+  parts.push(`## ${date}`, "");
+
+  for (let i = 0; i < newItems.length; i++) {
+    const item = newItems[i];
+    const key = archiveKey(item);
+    const { excerpt, tags } = renderItemBody(item);
+
+    parts.push(
+      `${i + 1}. **${item.title}**`,
+      `🔗 ${key}`,
+      `📍 ${item.domain}${tags}`,
+      excerpt,
+    );
+  }
+
+  return `${parts.join("\n")}\n`;
+}
+
+/**
+ * Build the text to append to the per-year archive file.
+ *
+ * 编排：提取已有 key（含上一年档案，用于跨年重试去重）→ 过滤新条目 → 渲染。
+ * 返回 "" 表示全部重复。
+ * Contract: every item line includes a `🔗 <key>` line so a later run can
+ * re-extract keys via {@link ARCHIVE_LINK_RE}.
+ *
+ * @param previousYearContent - 上一年档案内容；仅当本年文件尚为空时由编排方提供
+ *   （无上一年的文件时为空字符串）。防止跨年失败的批次在次年文件里重复归档。
+ */
+export function buildArchiveEntry(
+  date: string,
+  items: BookmarkItem[],
+  existingContent: string,
+  previousYearContent = "",
+): string {
+  const keys = extractArchiveKeys(existingContent);
+  for (const key of extractArchiveKeys(previousYearContent)) {
+    keys.add(key);
+  }
+  const newItems = selectNewArchiveItems(items, keys);
+  if (newItems.length === 0) return "";
+  return renderArchiveEntry(date, newItems, existingContent.length === 0);
+}
+
 // ── Task definition ────────────────────────────────────
 
 const CHECKPOINT_PATH = join(
@@ -96,6 +212,8 @@ const CHECKPOINT_PATH = join(
   "agent",
   "raindrop-bookmarks-checkpoint.json",
 );
+
+const ARCHIVE_DIR = join(homedir(), "work", "notes", "Calendar", "DailyNotes");
 
 export default createBookmarkTask<BookmarkItem>({
   id: "raindrop-bookmarks-fetch",
@@ -113,4 +231,9 @@ export default createBookmarkTask<BookmarkItem>({
   },
   computeIncrement,
   formatIncrement,
+  archive: {
+    dir: ARCHIVE_DIR,
+    buildFileName: (year) => `raindrop-bookmarks-${year}.md`,
+    buildEntry: buildArchiveEntry,
+  },
 });

--- a/extensions/shared/bookmark-pipeline.test.ts
+++ b/extensions/shared/bookmark-pipeline.test.ts
@@ -1,11 +1,31 @@
-import { describe, expect, it, vi } from "vitest";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupDir, tempDir } from "../scheduled-tasks/tasks/test-utils.ts";
 import {
+  type ArchiveConfig,
   type BookmarkTaskConfig,
+  buildArchiveFailureMessage,
   createBookmarkTask,
   type IncrementDecision,
+  localDateString,
   prepareBookmarkChunks,
 } from "./bookmark-pipeline.ts";
 import type { ExecContext } from "./deferred-queue/types.ts";
+
+// ── Telegram mock ─────────────────────────────────────
+
+const { sendTelegramNotificationMock } = vi.hoisted(() => ({
+  sendTelegramNotificationMock: vi.fn(),
+}));
+
+vi.mock("./telegram.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./telegram.ts")>();
+  return {
+    ...actual,
+    sendTelegramNotification: sendTelegramNotificationMock,
+  };
+});
 
 // ── Fixtures ──────────────────────────────────────────
 
@@ -196,5 +216,199 @@ describe("createBookmarkTask", () => {
     expect(result[0].html).toContain("📑 Prefix");
     expect(result[0].html).toContain("<b>1. First</b>");
     expect(result[0].html).toContain("<b>2. Second</b>");
+  });
+});
+
+// ── Archive (per-year markdown sink) ──────────────────
+
+/**
+ * Minimal archive config that echoes a marker + the first item title.
+ */
+function testArchive(dir: string): ArchiveConfig<TestBookmark> {
+  return {
+    dir,
+    buildFileName: (year) => `bookmarks-${year}.md`,
+    buildEntry: (date, items, existingContent) =>
+      `archive:${date}:${existingContent.length}:${items[0]?.title ?? ""}`,
+  };
+}
+
+describe("localDateString", () => {
+  it("formats a local date as YYYY-MM-DD", () => {
+    expect(localDateString(new Date(2026, 6, 31, 12, 0, 0))).toBe("2026-07-31");
+  });
+
+  it("keeps year and date consistent at a year boundary", () => {
+    expect(localDateString(new Date(2026, 11, 31, 23, 30, 0))).toBe(
+      "2026-12-31",
+    );
+  });
+});
+
+describe("buildArchiveFailureMessage", () => {
+  it("includes the file path and error, but no bookmark content", () => {
+    const msg = buildArchiveFailureMessage("/tmp/x/archive.md", "boom");
+    expect(msg).toContain("档案写入失败");
+    expect(msg).toContain("x/archive.md");
+    expect(msg).toContain("boom");
+  });
+});
+
+describe("createBookmarkTask archive integration", () => {
+  let dir: string;
+  let checkpointPath: string;
+
+  beforeEach(() => {
+    dir = tempDir("archive-test-");
+    checkpointPath = join(dir, "checkpoint.json");
+    sendTelegramNotificationMock.mockReset();
+    sendTelegramNotificationMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanupDir(dir);
+  });
+
+  it("writes the archive, sends Telegram, then saves checkpoint", async () => {
+    const config = testConfig({
+      checkpointPath,
+      archive: testArchive(dir),
+    });
+    const task = createBookmarkTask(config);
+    const exec = vi.fn().mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify([
+        { id: "2", title: "world" },
+        { id: "1", title: "hello" },
+      ]),
+      stderr: "",
+    });
+
+    await task.handler({ exec } as unknown as ExecContext);
+
+    // Archive file created with the entry text
+    const files = readdirSync(dir).filter((f) =>
+      /^bookmarks-\d{4}\.md$/.test(f),
+    );
+    expect(files).toHaveLength(1);
+    const content = readFileSync(join(dir, files[0]), "utf8");
+    expect(content).toContain("archive:");
+    expect(content).toContain("world");
+
+    // Telegram delivered and checkpoint advanced
+    expect(sendTelegramNotificationMock).toHaveBeenCalled();
+    expect(existsSync(checkpointPath)).toBe(true);
+  });
+
+  it("writes the archive even when Telegram delivery fails (archive-first)", async () => {
+    sendTelegramNotificationMock.mockRejectedValue(new Error("telegram down"));
+    const config = testConfig({
+      checkpointPath,
+      archive: testArchive(dir),
+    });
+    const task = createBookmarkTask(config);
+    const exec = vi.fn().mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify([{ id: "1", title: "hello" }]),
+      stderr: "",
+    });
+
+    await expect(
+      task.handler({ exec } as unknown as ExecContext),
+    ).resolves.toBeUndefined();
+
+    // Archive was written before Telegram attempted delivery
+    const files = readdirSync(dir).filter((f) =>
+      /^bookmarks-\d{4}\.md$/.test(f),
+    );
+    expect(files).toHaveLength(1);
+
+    // Checkpoint not advanced because Telegram failed
+    expect(existsSync(checkpointPath)).toBe(false);
+  });
+
+  it("skips the archive write when buildEntry returns empty, but still delivers", async () => {
+    const config = testConfig({
+      checkpointPath,
+      archive: { ...testArchive(dir), buildEntry: () => "" },
+    });
+    const task = createBookmarkTask(config);
+    const exec = vi.fn().mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify([{ id: "1", title: "hello" }]),
+      stderr: "",
+    });
+
+    await task.handler({ exec } as unknown as ExecContext);
+
+    const files = readdirSync(dir).filter((f) =>
+      /^bookmarks-\d{4}\.md$/.test(f),
+    );
+    expect(files).toHaveLength(0);
+    expect(sendTelegramNotificationMock).toHaveBeenCalled();
+    expect(existsSync(checkpointPath)).toBe(true);
+  });
+
+  it("fails fast on archive write error: no chunks, no checkpoint, error alert", async () => {
+    // archive.dir points at an existing regular file → mkdir throws ENOTDIR
+    const blocker = join(dir, "blocker");
+    writeFileSync(blocker, "i am a file");
+
+    const config = testConfig({
+      checkpointPath,
+      archive: { ...testArchive(blocker) },
+    });
+    const task = createBookmarkTask(config);
+    const exec = vi.fn().mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify([{ id: "1", title: "hello" }]),
+      stderr: "",
+    });
+
+    await expect(
+      task.handler({ exec } as unknown as ExecContext),
+    ).resolves.toBeUndefined();
+
+    // Exactly one Telegram call: the failure alert, not bookmark chunks
+    expect(sendTelegramNotificationMock).toHaveBeenCalledTimes(1);
+    const alert = String(sendTelegramNotificationMock.mock.calls[0][0]);
+    expect(alert).toContain("档案写入失败");
+    expect(alert).not.toContain("hello");
+    // The alert is pre-built HTML (message builder already escapes dynamic
+    // parts) — it must be sent raw, otherwise it is escaped a second time.
+    expect(alert).toContain("<code>");
+    expect(sendTelegramNotificationMock.mock.calls[0][2]).toBe(true);
+
+    // Checkpoint not advanced
+    expect(existsSync(checkpointPath)).toBe(false);
+  });
+
+  it("passes previous-year content to buildEntry when the year file is fresh", async () => {
+    const currentYear = String(new Date().getFullYear());
+    const prevYear = String(Number(currentYear) - 1);
+    writeFileSync(join(dir, `bookmarks-${prevYear}.md`), "prev-year-content");
+
+    const config = testConfig({
+      checkpointPath,
+      archive: {
+        ...testArchive(dir),
+        buildEntry: (_date, _items, existing, previous) =>
+          `existing=${existing.length}:previous=${previous.length}`,
+      },
+    });
+    const task = createBookmarkTask(config);
+    const exec = vi.fn().mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify([{ id: "1", title: "hello" }]),
+      stderr: "",
+    });
+
+    await task.handler({ exec } as unknown as ExecContext);
+
+    const content = readFileSync(
+      join(dir, `bookmarks-${currentYear}.md`),
+      "utf8",
+    );
+    expect(content).toBe("existing=0:previous=17");
   });
 });

--- a/extensions/shared/bookmark-pipeline.ts
+++ b/extensions/shared/bookmark-pipeline.ts
@@ -13,6 +13,8 @@
  * No IO, no side effects — fully testable. 工厂函数处理所有编排。
  */
 
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   loadCheckpoint as _loadCheckpoint,
   saveCheckpoint as _saveCheckpoint,
@@ -21,7 +23,7 @@ import { type HtmlChunk, prepareChunks, splitEntries } from "./chunking.ts";
 import { defineTask } from "./deferred-queue/define-task.ts";
 import { log } from "./deferred-queue/logger.ts";
 import type { Duration } from "./deferred-queue/types.ts";
-import { sendTelegramNotification } from "./telegram.ts";
+import { escapeHtml, sendTelegramNotification } from "./telegram.ts";
 
 // ── JSON parsing ───────────────────────────────────────
 
@@ -120,6 +122,96 @@ export function buildTruncationWarning(limit: number): string {
   return `上次 job 后有大量新增收藏，本次只拉取到前 ${limit} 条，结果可能不完整。`;
 }
 
+// ── Archive (per-year markdown sink) ───────────────────
+
+/**
+ * Optional archive configuration for a bookmark task.
+ *
+ * When configured, each run appends the newly-fetched items to a per-year
+ * markdown file after formatting and BEFORE any Telegram delivery. A failed
+ * archive write aborts the whole run (fail-fast): no Telegram chunks are
+ * sent and the checkpoint is not advanced, so the batch retries next run
+ * (deduping keeps the file idempotent).
+ *
+ * Leave `archive` unset to keep the exact legacy behavior.
+ */
+export interface ArchiveConfig<B> {
+  /** Archive root directory (absolute path); the year is embedded in the file name. */
+  dir: string;
+  /** Build the per-year file name, e.g. "raindrop-bookmarks-2026.md". */
+  buildFileName: (year: string) => string;
+  /**
+   * Pure: given today's local date (YYYY-MM-DD), the newly-fetched items and
+   * the current file content, produce the text to append. Return "" when
+   * everything is a duplicate and nothing should be written. May emit a
+   * file title when `existingContent` is empty (first creation).
+   *
+   * `previousYearContent` is the previous year's file content, provided only
+   * while the current year's file is still empty ("" when there is no
+   * previous file). Honor its keys so a batch archived in December but
+   * retried after Jan 1 is not duplicated into a fresh year file.
+   */
+  buildEntry: (
+    date: string,
+    items: B[],
+    existingContent: string,
+    previousYearContent: string,
+  ) => string;
+}
+
+/**
+ * Local date as YYYY-MM-DD.
+ *
+ * Year and date derive from the same source, so a run at a year boundary
+ * can never disagree about which year file to use vs. which date header.
+ */
+export function localDateString(now: Date = new Date()): string {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Build the Telegram error notification for a failed archive write.
+ *
+ * Deliberately contains no bookmark content — it is a failure alert only.
+ */
+export function buildArchiveFailureMessage(
+  filePath: string,
+  error: string,
+): string {
+  return [
+    "❌ 书签档案写入失败，本次任务已中止",
+    "",
+    `文件：<code>${escapeHtml(filePath)}</code>`,
+    `错误：${escapeHtml(error)}`,
+    "",
+    "下次运行时将自动重试。",
+  ].join("\n");
+}
+
+/**
+ * Read the previous year's archive file content.
+ *
+ * Only consulted while the current year's file is still empty: a fail-fast
+ * retry that crosses a year boundary would otherwise append the same batch
+ * to both year files. Returns "" when there is no previous file.
+ */
+function readPreviousYearArchive<B>(
+  archive: ArchiveConfig<B>,
+  year: string,
+  existingContent: string,
+): string {
+  if (existingContent) return "";
+  const prevPath = join(
+    archive.dir,
+    archive.buildFileName(String(Number(year) - 1)),
+  );
+  if (!existsSync(prevPath)) return "";
+  return readFileSync(prevPath, "utf8");
+}
+
 // ── Shared types for createBookmarkTask ─────────────────
 
 /**
@@ -190,6 +282,13 @@ export interface BookmarkTaskConfig<B> {
    */
   formatIncrement: (items: B[], warning?: string) => string;
 
+  /**
+   * Optional per-year markdown archive. When set, newly-fetched items are
+   * appended to `<dir>/<buildFileName(year)>.md` before Telegram delivery,
+   * with fail-fast semantics on write errors. Default: no archive.
+   */
+  archive?: ArchiveConfig<B>;
+
   /** Max items to fetch per run (default: 50). */
   limit?: number;
   /** Max HTML length per Telegram chunk (default: 4096). */
@@ -224,6 +323,7 @@ export function createBookmarkTask<B>(
     buildPrefix,
     computeIncrement,
     formatIncrement,
+    archive,
     limit = 50,
     maxHtmlLength = 4096,
   } = config;
@@ -294,6 +394,53 @@ export function createBookmarkTask<B>(
 
       const markdown = formatIncrement(decision.items, warning);
       const prefix = buildPrefix(decision, decision.items.length);
+
+      // ── 4.5 Shell: write per-year archive (fail-fast) ──────
+      if (archive) {
+        const today = localDateString();
+        const year = today.slice(0, 4);
+        const filePath = join(archive.dir, archive.buildFileName(year));
+        try {
+          const existing = existsSync(filePath)
+            ? readFileSync(filePath, "utf8")
+            : "";
+          // Year-boundary safety: while this year's file is still empty,
+          // also honor keys from the previous year's file so a batch that
+          // was archived in December but retried after Jan 1 is not
+          // duplicated into the fresh year file.
+          const previousYearContent = readPreviousYearArchive(
+            archive,
+            year,
+            existing,
+          );
+          const entry = archive.buildEntry(
+            today,
+            decision.items,
+            existing,
+            previousYearContent,
+          );
+          if (entry) {
+            mkdirSync(archive.dir, { recursive: true });
+            appendFileSync(filePath, entry, "utf8");
+            log.info("archive appended", { filePath });
+          } else {
+            log.info("archive skipped (all duplicates)", { filePath });
+          }
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          log.warn("archive write failed", { filePath, error: errorMsg });
+          // buildArchiveFailureMessage already escapes its dynamic parts —
+          // send it raw so the <code> markup is not escaped a second time.
+          await sendTelegramNotification(
+            buildArchiveFailureMessage(filePath, errorMsg),
+            undefined,
+            true,
+          ).catch((e) =>
+            log.warn("telegram notify failed", { error: String(e) }),
+          );
+          return; // fail-fast: no Telegram chunks, no checkpoint advance
+        }
+      }
 
       // ── 5. Pure: chunk Markdown into Telegram HTML ──────────
       const chunks = prepareBookmarkChunks({

--- a/extensions/shared/telegram.ts
+++ b/extensions/shared/telegram.ts
@@ -37,7 +37,13 @@ export interface TelegramConfig {
 const buildTelegramUrl = (botToken: string, method: string): string =>
   `https://api.telegram.org/bot${botToken}/${method}`;
 
-const escapeHtml = (text: string): string =>
+/**
+ * Escape text for Telegram HTML (only & < > ").
+ *
+ * Exported so other modules (e.g. bookmark-pipeline, knowledge-wiki-daily)
+ * can reuse it instead of maintaining private copies.
+ */
+export const escapeHtml = (text: string): string =>
   text
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")


### PR DESCRIPTION
- Add optional ArchiveConfig to shared bookmark pipeline; archive written before Telegram with fail-fast semantics (write failure aborts run, sends error alert, skips checkpoint)
- Enable per-year archive for raindrop-bookmarks task writing to ~/work/notes/Calendar/DailyNotes/<year>/raindrop-bookmarks-<year>.md
- Dedupe by link (fallback title) against current and previous-year archive content for idempotent cross-year writes
- Split pure core: selectNewArchiveItems, renderArchiveEntry, localDateString, buildArchiveFailureMessage
- Export escapeHtml from telegram.ts and reuse in bookmark-pipeline and knowledge-wiki-daily (remove duplicated private copies)
- Add tests: archive integration (write order, empty skip, fail-fast, cross-year previous content) and raindrop entry format/dedupe