### PR TITLE
feat(review): run review turns on a configurable fixed model

### DIFF
--- a/extensions/review/review-config.test.ts
+++ b/extensions/review/review-config.test.ts
@@ -1,0 +1,211 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearSettingsCache, getSettingsPaths } from "../shared/settings.js";
+import {
+  DEFAULT_REVIEW_MODEL,
+  extractModelOverride,
+  getReviewModel,
+  parseModelId,
+  resolveReviewModel,
+} from "./review-config.js";
+
+const tempDirs: string[] = [];
+const originalHome = process.env.HOME;
+
+const registerTempDir = (dir: string): string => {
+  tempDirs.push(dir);
+  return dir;
+};
+
+const createTempDir = (prefix: string): string =>
+  registerTempDir(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+
+const createTempHome = (): string => {
+  const dir = createTempDir("pi-kit-review-home-");
+  process.env.HOME = dir;
+  return dir;
+};
+
+const restoreHome = (): void => {
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+};
+
+const writeSettings = (
+  cwd: string,
+  record: unknown,
+  scope: "global" | "project",
+): void => {
+  const { globalPath, projectPath } = getSettingsPaths(cwd);
+  const file = scope === "global" ? globalPath : projectPath;
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(record), "utf-8");
+};
+
+afterEach(() => {
+  clearSettingsCache();
+  restoreHome();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolveReviewModel (pure decision)", () => {
+  it("defaults to kimi-k3 when nothing is configured", () => {
+    expect(resolveReviewModel(undefined, undefined)).toBe(
+      "cc-switch-gateway/llm-gateway--kimi-k3",
+    );
+    expect(resolveReviewModel({}, undefined)).toBe(
+      "cc-switch-gateway/llm-gateway--kimi-k3",
+    );
+  });
+
+  it("uses the configured model when present", () => {
+    expect(resolveReviewModel({ model: "opencode-go/deepseek-v4-pro" })).toBe(
+      "opencode-go/deepseek-v4-pro",
+    );
+  });
+
+  it('returns undefined (disabled) when configured as "off"', () => {
+    expect(resolveReviewModel({ model: "off" })).toBeUndefined();
+  });
+
+  it("treats an empty config value as unset (falls back to default)", () => {
+    expect(resolveReviewModel({ model: "" })).toBe(DEFAULT_REVIEW_MODEL);
+    expect(resolveReviewModel({ model: "   " })).toBe(DEFAULT_REVIEW_MODEL);
+  });
+
+  it("ignores a whitespace-only --model override", () => {
+    expect(resolveReviewModel(undefined, "   ")).toBe(DEFAULT_REVIEW_MODEL);
+  });
+
+  it("lets --model override even an explicit off for one call", () => {
+    expect(
+      resolveReviewModel({ model: "off" }, "opencode-go/deepseek-v4-pro"),
+    ).toBe("opencode-go/deepseek-v4-pro");
+  });
+});
+
+describe("getReviewModel (settings shell)", () => {
+  it("defaults to kimi-k3 when nothing is configured", () => {
+    createTempHome();
+    const cwd = createTempDir("pi-kit-review-cwd-");
+    expect(getReviewModel(cwd)).toBe("cc-switch-gateway/llm-gateway--kimi-k3");
+  });
+
+  it("reads the configured model from the global settings file", () => {
+    createTempHome();
+    const cwd = createTempDir("pi-kit-review-cwd-");
+    writeSettings(
+      cwd,
+      {
+        third_extensions: { review: { model: "opencode-go/deepseek-v4-pro" } },
+      },
+      "global",
+    );
+    expect(getReviewModel(cwd)).toBe("opencode-go/deepseek-v4-pro");
+  });
+
+  it('returns undefined (disabled) when configured as "off"', () => {
+    createTempHome();
+    const cwd = createTempDir("pi-kit-review-cwd-");
+    writeSettings(
+      cwd,
+      {
+        third_extensions: { review: { model: "off" } },
+      },
+      "global",
+    );
+    expect(getReviewModel(cwd)).toBeUndefined();
+  });
+
+  it("lets the project file override the global one", () => {
+    createTempHome();
+    const cwd = createTempDir("pi-kit-review-cwd-");
+    writeSettings(
+      cwd,
+      {
+        third_extensions: {
+          review: { model: "cc-switch-gateway/llm-gateway--kimi-k3" },
+        },
+      },
+      "global",
+    );
+    writeSettings(
+      cwd,
+      {
+        third_extensions: { review: { model: "deepseek/deepseek-v4-pro" } },
+      },
+      "project",
+    );
+    expect(getReviewModel(cwd)).toBe("deepseek/deepseek-v4-pro");
+  });
+
+  it("lets /review --model override the config for one call", () => {
+    createTempHome();
+    const cwd = createTempDir("pi-kit-review-cwd-");
+    writeSettings(
+      cwd,
+      {
+        third_extensions: { review: { model: "off" } },
+      },
+      "global",
+    );
+    expect(getReviewModel(cwd, "opencode-go/deepseek-v4-pro")).toBe(
+      "opencode-go/deepseek-v4-pro",
+    );
+  });
+});
+
+describe("parseModelId", () => {
+  it("splits provider/id on the first slash", () => {
+    expect(parseModelId("cc-switch-gateway/llm-gateway--kimi-k3")).toEqual({
+      provider: "cc-switch-gateway",
+      id: "llm-gateway--kimi-k3",
+    });
+    expect(parseModelId("opencode-go/deepseek-v4-flash")).toEqual({
+      provider: "opencode-go",
+      id: "deepseek-v4-flash",
+    });
+  });
+
+  it("returns null for inputs without a valid slash", () => {
+    expect(parseModelId("no-slash")).toBeNull();
+    expect(parseModelId("")).toBeNull();
+    expect(parseModelId("/leading-slash")).toBeNull();
+    expect(parseModelId("provider/")).toBeNull();
+  });
+});
+
+describe("extractModelOverride", () => {
+  it("strips a leading --model <id>", () => {
+    expect(extractModelOverride("--model X uncommitted")).toEqual({
+      model: "X",
+      rest: "uncommitted",
+    });
+    expect(extractModelOverride("--model X")).toEqual({
+      model: "X",
+      rest: "",
+    });
+  });
+
+  it("leaves args without an override untouched", () => {
+    expect(extractModelOverride("uncommitted")).toEqual({
+      model: undefined,
+      rest: "uncommitted",
+    });
+    expect(extractModelOverride("branch main")).toEqual({
+      model: undefined,
+      rest: "branch main",
+    });
+    expect(extractModelOverride(undefined)).toEqual({
+      model: undefined,
+      rest: "",
+    });
+  });
+});

--- a/extensions/review/review-config.ts
+++ b/extensions/review/review-config.ts
@@ -1,0 +1,91 @@
+/**
+ * Review extension configuration.
+ *
+ * Resolves which model runs the review turn ("审模型"):
+ * - priority: `/review --model <id>` (single-invocation override)
+ *           > `third_extensions.review.model` (config; project overrides global)
+ *           > DEFAULT_REVIEW_MODEL (default-enabled)
+ * - config value "off" disables the feature (review behaves exactly as before).
+ *
+ * Decision logic lives in `resolveReviewModel` (pure, value in / value out);
+ * `getReviewModel` is a thin shell that reads the settings file, converts it
+ * to the config DTO, and delegates to the pure function. Shell side
+ * (review.ts) performs the actual model switch via `pi.setModel`.
+ */
+
+import { loadSettings } from "../shared/settings.ts";
+
+export const DEFAULT_REVIEW_MODEL = "cc-switch-gateway/llm-gateway--kimi-k3";
+export const REVIEW_MODEL_OFF = "off";
+
+/** Boundary DTO — the review config slice the decision logic needs. */
+export type ReviewModelConfig = { model?: string };
+
+/**
+ * Pure decision: resolve the review model id, or `undefined` when the feature
+ * is disabled.
+ *
+ * - `argsModel` (from `/review --model <id>`) wins over config for one call.
+ * - Config missing/empty → DEFAULT_REVIEW_MODEL (feature is default-on).
+ * - Config value "off" → disabled (current behavior).
+ */
+export function resolveReviewModel(
+  config: ReviewModelConfig | undefined,
+  argsModel?: string,
+): string | undefined {
+  if (argsModel?.trim()) {
+    return argsModel.trim();
+  }
+
+  const configured = config?.model;
+
+  if (configured === undefined || configured.trim() === "") {
+    return DEFAULT_REVIEW_MODEL;
+  }
+  if (configured.trim() === REVIEW_MODEL_OFF) {
+    return undefined;
+  }
+  return configured.trim();
+}
+
+/**
+ * Thin shell: read merged settings (global + project) and delegate to the
+ * pure decision function.
+ */
+export function getReviewModel(
+  cwd: string,
+  argsModel?: string,
+): string | undefined {
+  const settings = loadSettings(cwd).merged as {
+    third_extensions?: { review?: ReviewModelConfig };
+  };
+  return resolveReviewModel(settings.third_extensions?.review, argsModel);
+}
+
+/**
+ * Split a "provider/modelId" string on the first "/".
+ * Returns null for empty input or when there is no "/" (or it is malformed).
+ */
+export function parseModelId(
+  s: string,
+): { provider: string; id: string } | null {
+  if (!s) return null;
+  const idx = s.indexOf("/");
+  if (idx <= 0 || idx === s.length - 1) return null;
+  return { provider: s.slice(0, idx), id: s.slice(idx + 1) };
+}
+
+/**
+ * Strip a leading "--model <id>" from /review command args.
+ * Only the prefix form is supported; returns the remaining args unchanged
+ * when there is no override.
+ */
+export function extractModelOverride(args: string | undefined): {
+  model: string | undefined;
+  rest: string;
+} {
+  if (!args?.trim()) return { model: undefined, rest: args ?? "" };
+  const match = args.trim().match(/^--model\s+(\S+)(?:\s+([\s\S]*))?$/);
+  if (!match) return { model: undefined, rest: args };
+  return { model: match[1], rest: match[2] ?? "" };
+}

--- a/extensions/review/review.ts
+++ b/extensions/review/review.ts
@@ -40,6 +40,11 @@ import {
   SelectList,
   Text,
 } from "@earendil-works/pi-tui";
+import {
+  extractModelOverride,
+  getReviewModel,
+  parseModelId,
+} from "./review-config.ts";
 
 // State to track fresh session review (where we branched from).
 // Module-level state means only one review can be active at a time.
@@ -1389,13 +1394,48 @@ export default function reviewExtension(pi: ExtensionAPI) {
   }
 
   /**
+   * Switch the session to the configured review model for this review pass.
+   * Returns `true` when a switch actually happened (caller must restore the
+   * work model afterwards); `false` when disabled/not resolvable/unavailable —
+   * the pass then degrades to the current model (with a visible warning).
+   */
+  async function assertReviewModel(
+    ctx: ExtensionCommandContext,
+    cwd: string,
+    argsModel?: string,
+  ): Promise<boolean> {
+    const modelId = getReviewModel(cwd, argsModel);
+    if (!modelId) {
+      return false; // disabled ("off") — current behavior
+    }
+    const parsed = parseModelId(modelId);
+    const model = parsed && ctx.modelRegistry.find(parsed.provider, parsed.id);
+    if (!model) {
+      ctx.ui.notify(
+        `Review model unavailable (${modelId}), using current model for this pass.`,
+        "warning",
+      );
+      return false;
+    }
+    const ok = await pi.setModel(model);
+    if (!ok) {
+      ctx.ui.notify(
+        `Review model switch failed (${modelId}), using current model for this pass.`,
+        "warning",
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
    * Execute the review
    */
   async function executeReview(
     ctx: ExtensionCommandContext,
     target: ReviewTarget,
     useFreshSession: boolean,
-    options?: { includeLocalChanges?: boolean },
+    options?: { includeLocalChanges?: boolean; argsModel?: string },
   ): Promise<boolean> {
     // Check if we're already in a review
     if (reviewOriginId) {
@@ -1488,8 +1528,29 @@ export default function reviewExtension(pi: ExtensionAPI) {
     const modeHint = useFreshSession ? " (fresh session)" : "";
     ctx.ui.notify(`Starting review: ${hint}${modeHint}`, "info");
 
+    // Switch to the configured review model for this pass (degrade with a
+    // warning when unavailable). Snapshot the work model before the switch so
+    // we can restore it after the review turn completes.
+    const workModel = ctx.model;
+    const switched = await assertReviewModel(ctx, ctx.cwd, options?.argsModel);
+
     // Send as a user message that triggers a turn
     pi.sendUserMessage(fullPrompt);
+
+    // Wait for the review turn to settle, then restore the work model.
+    // The session stays on the review model for the whole turn (review + any
+    // follow-up tool calls), and returns to the work model afterwards.
+    await ctx.waitForIdle();
+    if (switched) {
+      const restored = await pi.setModel(workModel);
+      if (!restored) {
+        ctx.ui.notify(
+          "Failed to restore work model after review. Use /model to switch back.",
+          "warning",
+        );
+      }
+    }
+
     return true;
   }
 
@@ -1612,6 +1673,7 @@ export default function reviewExtension(pi: ExtensionAPI) {
   async function runLoopFixingReview(
     ctx: ExtensionCommandContext,
     target: ReviewTarget,
+    argsModel?: string,
   ): Promise<void> {
     if (reviewLoopInProgress) {
       ctx.ui.notify("Loop fixing review is already running.", "warning");
@@ -1630,6 +1692,7 @@ export default function reviewExtension(pi: ExtensionAPI) {
         const reviewBaselineAssistantId = getLastAssistantSnapshot(ctx)?.id;
         const started = await executeReview(ctx, target, true, {
           includeLocalChanges: true,
+          argsModel,
         });
         if (!started) {
           ctx.ui.notify(
@@ -1810,10 +1873,13 @@ export default function reviewExtension(pi: ExtensionAPI) {
         return;
       }
 
-      // Try to parse direct arguments
+      // Try to parse direct arguments (--model <id> single-invocation override
+      // is stripped first; it overrides the configured review model for this
+      // review only and never writes config).
+      const { model: argsModel, rest: reviewArgs } = extractModelOverride(args);
       let target: ReviewTarget | null = null;
       let fromSelector = false;
-      const parsed = parseArgs(args);
+      const parsed = parseArgs(reviewArgs);
 
       if (parsed) {
         if (parsed.type === "pr") {
@@ -1855,7 +1921,7 @@ export default function reviewExtension(pi: ExtensionAPI) {
         }
 
         if (reviewLoopFixingEnabled) {
-          await runLoopFixingReview(ctx, target);
+          await runLoopFixingReview(ctx, target, argsModel);
           return;
         }
 
@@ -1886,7 +1952,7 @@ export default function reviewExtension(pi: ExtensionAPI) {
           useFreshSession = choice === "Empty branch";
         }
 
-        await executeReview(ctx, target, useFreshSession);
+        await executeReview(ctx, target, useFreshSession, { argsModel });
         return;
       }
     },


### PR DESCRIPTION
- add review-config.ts decision core: --model override > config > default kimi-k3 ("off" disables)
- switch the session to the review model per pass and restore the work model after the turn
- support /review --model <id> single-invocation override
- add unit tests for the pure decision core and the settings read shell