### PR TITLE
fix(scheduled-tasks): run wiki-summarize batches concurrently with locked concept writes

### DIFF
--- a/extensions/scheduled-tasks/tasks/knowledge-wiki-daily.test.ts
+++ b/extensions/scheduled-tasks/tasks/knowledge-wiki-daily.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
+  aggregateBatchResults,
   buildSubagentPrompt,
   parseResultJson,
   runQmdStep,
@@ -24,6 +25,54 @@ const WIKI_SUMMARIZE_FILE = path.resolve(
   "prompts",
   "wiki-summarize.md",
 );
+
+// ── Test helpers ──────────────────────────────────────
+
+/**
+ * Create a subagent mock whose calls only resolve when manually resolved.
+ * Lets tests control completion order / concurrency deterministically.
+ */
+function deferredSubagentMock() {
+  const resolvers: Array<(value: unknown) => void> = [];
+  let inFlight = 0;
+  let maxInFlight = 0;
+
+  const subagent = vi.fn().mockImplementation(() => {
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    return new Promise((resolve) => {
+      resolvers.push((value: unknown) => {
+        inFlight--;
+        resolve(value);
+      });
+    });
+  });
+
+  return {
+    subagent,
+    resolvers,
+    get maxInFlight() {
+      return maxInFlight;
+    },
+  };
+}
+
+/**
+ * Build a successful subagent result. A batch number tags the done text and
+ * adds one summary file; batch 0 produces an empty summary list.
+ */
+function makeOkResult(batch = 0) {
+  return {
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+    summary: JSON.stringify({
+      ok: true,
+      done: batch ? `batch-${batch} done` : "done",
+      summaries: batch ? [`Wiki/Summaries/B${batch}.summary.md`] : [],
+    }),
+  };
+}
 
 // ── buildSubagentPrompt ───────────────────────────────
 
@@ -288,6 +337,45 @@ describe("runQmdStep", () => {
   });
 });
 
+// ── aggregateBatchResults ─────────────────────────────
+
+describe("aggregateBatchResults", () => {
+  it("accumulates summaries and done text in batch order", () => {
+    const result = aggregateBatchResults([
+      { ok: true, done: "a", summaries: ["S1", "S2"] },
+      { ok: true, done: "b" },
+    ]);
+    expect(result.createdSummaries).toEqual(["S1", "S2"]);
+    expect(result.wikiSummaryDone).toBe("Batch 1: a | Batch 2: b");
+    expect(result.failed).toEqual([]);
+  });
+
+  it("collects failed batches and skips them in the output", () => {
+    const result = aggregateBatchResults([
+      { ok: true, done: "a", summaries: ["S1"] },
+      { ok: false, done: "boom" },
+      { ok: true, done: "c", summaries: ["S3"] },
+    ]);
+    expect(result.createdSummaries).toEqual(["S1", "S3"]);
+    expect(result.wikiSummaryDone).toBe("Batch 1: a | Batch 3: c");
+    expect(result.failed).toEqual([{ batch: 2, error: "boom" }]);
+  });
+
+  it("uses 'unknown error' when a failed batch has no message", () => {
+    const result = aggregateBatchResults([{ ok: false }]);
+    expect(result.failed).toEqual([{ batch: 1, error: "unknown error" }]);
+    expect(result.createdSummaries).toEqual([]);
+    expect(result.wikiSummaryDone).toBe("");
+  });
+
+  it("handles empty results", () => {
+    const result = aggregateBatchResults([]);
+    expect(result.createdSummaries).toEqual([]);
+    expect(result.wikiSummaryDone).toBe("");
+    expect(result.failed).toEqual([]);
+  });
+});
+
 // ── runSummarizePipeline ──────────────────────────────
 
 describe("runSummarizePipeline", () => {
@@ -298,82 +386,7 @@ describe("runSummarizePipeline", () => {
     expect(result.wikiSummaryDone).toBe("No stale files found.");
   });
 
-  it("accumulates summaries from multiple successful batches", async () => {
-    const exec = {
-      subagent: vi
-        .fn()
-        .mockResolvedValueOnce({
-          exitCode: 0,
-          stdout: "",
-          stderr: "",
-          summary: JSON.stringify({
-            ok: true,
-            done: "Phase 1-4 complete",
-            summaries: ["Wiki/Summaries/A.summary.md"],
-          }),
-        })
-        .mockResolvedValueOnce({
-          exitCode: 0,
-          stdout: "",
-          stderr: "",
-          summary: JSON.stringify({
-            ok: true,
-            done: "Phase 1-4 complete",
-            summaries: ["Wiki/Summaries/B.summary.md"],
-          }),
-        }),
-    };
-
-    // BATCH_SIZE = 3, so 4 files → 2 batches (3 + 1)
-    const result = await runSummarizePipeline(exec, [
-      "A.md",
-      "B.md",
-      "C.md",
-      "D.md",
-    ]);
-    expect(result.createdSummaries).toEqual([
-      "Wiki/Summaries/A.summary.md",
-      "Wiki/Summaries/B.summary.md",
-    ]);
-    expect(result.wikiSummaryDone).toContain("Batch 1");
-    expect(result.wikiSummaryDone).toContain("Batch 2");
-  });
-
-  it("continues processing remaining batches after one fails", async () => {
-    const exec = {
-      subagent: vi
-        .fn()
-        .mockResolvedValueOnce({
-          exitCode: 0,
-          stdout: "",
-          stderr: "",
-          summary: JSON.stringify({
-            ok: true,
-            done: "Batch 1 done",
-            summaries: ["Wiki/Summaries/A.summary.md"],
-          }),
-        })
-        .mockResolvedValueOnce({
-          exitCode: 1,
-          stdout: "",
-          stderr: "batch 2 failed",
-        }),
-    };
-
-    // BATCH_SIZE = 3, so 4 files → 2 batches (3 + 1)
-    // Batch 1 succeeds, batch 2 fails
-    const result = await runSummarizePipeline(exec, [
-      "A.md",
-      "B.md",
-      "C.md",
-      "D.md",
-    ]);
-    expect(result.createdSummaries).toEqual(["Wiki/Summaries/A.summary.md"]);
-    expect(result.wikiSummaryDone).toContain("Batch 1");
-    expect(result.wikiSummaryDone).not.toContain("Batch 2");
-  });
-
-  it("handles exception during iteration gracefully", async () => {
+  it("keeps collecting results when a subagent call rejects", async () => {
     const exec = {
       subagent: vi
         .fn()
@@ -390,8 +403,8 @@ describe("runSummarizePipeline", () => {
         .mockRejectedValueOnce(new Error("subagent crashed")),
     };
 
-    // BATCH_SIZE = 3, so 4 files → 2 batches (3 + 1)
-    // Batch 1 succeeds, batch 2 throws
+    // BATCH_SIZE = 3 → 4 files → 2 batches, run concurrently.
+    // Batch 1 succeeds, batch 2 throws; the throw only fails that batch.
     const result = await runSummarizePipeline(exec, [
       "A.md",
       "B.md",
@@ -399,44 +412,64 @@ describe("runSummarizePipeline", () => {
       "D.md",
     ]);
     expect(result.createdSummaries).toEqual(["Wiki/Summaries/A.summary.md"]);
+    expect(result.wikiSummaryDone).toContain("Batch 1");
+    expect(result.wikiSummaryDone).not.toContain("Batch 2");
   });
 
-  it("handles batch failure via ok:false result", async () => {
-    const exec = {
-      subagent: vi
-        .fn()
-        .mockResolvedValueOnce({
-          exitCode: 0,
-          stdout: "",
-          stderr: "",
-          summary: JSON.stringify({
-            ok: false,
-            done: "Phase 2 failed: cannot process",
-          }),
-        })
-        .mockResolvedValueOnce({
-          exitCode: 0,
-          stdout: "",
-          stderr: "",
-          summary: JSON.stringify({
-            ok: true,
-            done: "Batch 2 done",
-            summaries: ["Wiki/Summaries/B.summary.md"],
-          }),
-        }),
-    };
+  it("never runs more than 3 subagents at once and processes every batch", async () => {
+    const mock = deferredSubagentMock();
 
-    // BATCH_SIZE = 3, so 4 files → 2 batches (3 + 1)
-    // Batch 1 returns ok:false, batch 2 succeeds
-    const result = await runSummarizePipeline(exec, [
-      "A.md",
-      "B.md",
-      "C.md",
-      "D.md",
+    // BATCH_SIZE = 3 → 10 files → 4 batches.
+    const files = Array.from({ length: 10 }, (_, i) => `Notes/F${i}.md`);
+    const pipelinePromise = runSummarizePipeline(
+      { subagent: mock.subagent },
+      files,
+    );
+
+    // The pool starts at most 3; the 4th batch is scheduled only after a
+    // slot frees up — observable behavior, not internal timing.
+    await vi.waitFor(() => expect(mock.resolvers).toHaveLength(3));
+    mock.resolvers[0](makeOkResult());
+    await vi.waitFor(() => expect(mock.resolvers).toHaveLength(4));
+    mock.resolvers.slice(1).forEach((resolve) => {
+      resolve(makeOkResult());
+    });
+
+    const result = await pipelinePromise;
+    expect(mock.maxInFlight).toBe(3);
+    expect(mock.subagent).toHaveBeenCalledTimes(4);
+    expect(result.wikiSummaryDone).toContain("Batch 4");
+  });
+
+  it("collects results in batch order regardless of completion order", async () => {
+    const mock = deferredSubagentMock();
+
+    // BATCH_SIZE = 3 → 10 files → 4 batches.
+    const files = Array.from({ length: 10 }, (_, i) => `Notes/F${i}.md`);
+    const pipelinePromise = runSummarizePipeline(
+      { subagent: mock.subagent },
+      files,
+    );
+
+    await vi.waitFor(() => expect(mock.resolvers).toHaveLength(3));
+    // Resolve out of order: batch 3 first, then batch 2, batch 1, batch 4.
+    mock.resolvers[2](makeOkResult(3));
+    await vi.waitFor(() => expect(mock.resolvers).toHaveLength(4));
+    mock.resolvers[1](makeOkResult(2));
+    mock.resolvers[0](makeOkResult(1));
+    mock.resolvers[3](makeOkResult(4));
+
+    const result = await pipelinePromise;
+    // Collected in batch order, not completion order.
+    expect(result.createdSummaries).toEqual([
+      "Wiki/Summaries/B1.summary.md",
+      "Wiki/Summaries/B2.summary.md",
+      "Wiki/Summaries/B3.summary.md",
+      "Wiki/Summaries/B4.summary.md",
     ]);
-    // Should have continued past batch 1 and collected batch 2
-    expect(result.createdSummaries).toEqual(["Wiki/Summaries/B.summary.md"]);
-    expect(result.wikiSummaryDone).toContain("Batch 2");
+    expect(result.wikiSummaryDone).toBe(
+      "Batch 1: batch-1 done | Batch 2: batch-2 done | Batch 3: batch-3 done | Batch 4: batch-4 done",
+    );
   });
 });
 

--- a/extensions/scheduled-tasks/tasks/knowledge-wiki-daily.ts
+++ b/extensions/scheduled-tasks/tasks/knowledge-wiki-daily.ts
@@ -57,6 +57,21 @@ const QMD_EMBED_MODEL =
  */
 const BATCH_SIZE = 3;
 
+/**
+ * Maximum number of subagent batches to run concurrently.
+ * Each batch spawns its own isolated Pi process; this cap prevents
+ * overwhelming the machine / model with too many parallel agents.
+ */
+const MAX_CONCURRENT_BATCHES = 3;
+
+/**
+ * Per-batch subagent timeout (10 minutes).
+ * Batches run concurrently (up to MAX_CONCURRENT_BATCHES), so this bounds the
+ * worst-case wall-clock time to roughly
+ * ceil(batchCount / MAX_CONCURRENT_BATCHES) × 10 min.
+ */
+const SUBAGENT_TIMEOUT_MS = 600_000;
+
 // ── Subagent prompt builder ───────────────────────────────────────────────
 
 /**
@@ -224,7 +239,7 @@ async function listStaleFiles(exec: {
     return parsed.sources;
   } catch (err) {
     log.warn("list-stale threw", {
-      error: err instanceof Error ? err.message : String(err),
+      error: errorMessage(err),
     });
     return [];
   }
@@ -327,6 +342,20 @@ export interface BatchResult {
 }
 
 /**
+ * Pure: normalize an unknown thrown value into a human-readable message.
+ */
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Pure: convert a thrown error into a failed batch result.
+ */
+function toBatchFailure(err: unknown): BatchResult {
+  return { ok: false, done: errorMessage(err) };
+}
+
+/**
  * Pure: split an array into fixed-size batches.
  *
  * Pure — no side effects, no IO. Easy to test with table tests.
@@ -344,14 +373,102 @@ function partitionIntoBatches<T>(items: T[], batchSize: number): T[][] {
 }
 
 /**
+ * Pure: aggregate per-batch results into the pipeline outcome.
+ *
+ * Pure — no side effects, no IO. Failures are collected separately so the
+ * shell can decide how to surface them (logs, notifications) without the
+ * aggregation logic being entangled with side effects.
+ *
+ * @param results - Batch results in batch order
+ * @returns Aggregated outcome: created/updated summaries, done text, failures
+ */
+export interface PipelineAggregation {
+  createdSummaries: string[];
+  wikiSummaryDone: string;
+  failed: Array<{ batch: number; error: string }>;
+}
+
+/** @internal Exported for testing only. */
+export function aggregateBatchResults(
+  results: BatchResult[],
+): PipelineAggregation {
+  const createdSummaries: string[] = [];
+  const failed: Array<{ batch: number; error: string }> = [];
+  let wikiSummaryDone = "";
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+
+    if (!result.ok) {
+      failed.push({ batch: i + 1, error: result.done ?? "unknown error" });
+      continue;
+    }
+
+    if (result.summaries) {
+      createdSummaries.push(...result.summaries);
+    }
+    if (result.done) {
+      if (wikiSummaryDone) wikiSummaryDone += " | ";
+      wikiSummaryDone += `Batch ${i + 1}: ${result.done}`;
+    }
+  }
+
+  return { createdSummaries, wikiSummaryDone, failed };
+}
+
+/**
+ * Run batch jobs with bounded concurrency, collecting results in input order
+ * regardless of completion order.
+ *
+ * Fixed-size worker pool over a shared index cursor. Results are written at
+ * `results[index]`, so the final array is always in input order even when
+ * workers finish out of order.
+ *
+ * A job rejection degrades to a failed result (`{ ok: false, done }`) instead
+ * of rejecting the whole pool — partially collected results are never lost.
+ * Use `onRejected` for shell-side observability (e.g. logging) of throws.
+ *
+ * @param batches - Batches to process (each a stale-file list)
+ * @param concurrency - Max number of jobs running at once
+ * @param job - Async job; receives the batch and its index
+ * @param onRejected - Optional shell hook fired when a job throws
+ * @returns Results in input (batch) order
+ */
+async function runBatchesConcurrently(
+  batches: string[][],
+  concurrency: number,
+  job: (batch: string[], index: number) => Promise<BatchResult>,
+  onRejected?: (error: unknown, index: number) => void,
+): Promise<BatchResult[]> {
+  const results: BatchResult[] = new Array(batches.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= batches.length) break;
+      results[index] = await job(batches[index], index).catch((err) => {
+        onRejected?.(err, index);
+        return toBatchFailure(err);
+      });
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, batches.length) }, worker),
+  );
+  return results;
+}
+
+/**
  * Process a batch of stale files through a single Pi subagent call.
  *
  * Builds a scoped prompt for the batch, runs the wiki-summarize pipeline
  * (Phase 1-4), and returns the parsed result.
  *
- * The subagent has a generous timeout and the prompt template loaded via
- * --prompt-template. Each batch is independent — the subagent does not know
- * about other batches.
+ * The subagent has a 10-minute timeout (SUBAGENT_TIMEOUT_MS) and the prompt
+ * template loaded via --prompt-template. Each batch is independent — the
+ * subagent does not know about other batches.
  */
 async function processBatch(
   exec: {
@@ -381,7 +498,7 @@ async function processBatch(
   const result = await exec.subagent({
     prompt,
     promptTemplatePaths: [PROMPT_TEMPLATE_PATH],
-    timeoutMs: 300_000,
+    timeoutMs: SUBAGENT_TIMEOUT_MS,
   });
 
   const parsed = parseResultJson(result.summary);
@@ -459,7 +576,7 @@ export async function runQmdStep(
     log.info(`${label} completed`);
     return true;
   } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err);
+    const errorMsg = errorMessage(err);
     log.warn(`${label} threw`, { error: errorMsg });
 
     await sendTelegramNotification(
@@ -492,10 +609,19 @@ interface SummarizePipelineResult {
 
 /**
  * Run the wiki-summarize pipeline for all stale files, processing them
- * in independent batches via the Pi subagent.
+ * in independent batches via the Pi subagent with bounded concurrency
+ * (up to MAX_CONCURRENT_BATCHES at a time).
  *
  * Pure shell — handles IO (subagent calls, logging, Telegram notifications).
  * Returns accumulated results for the handler to use in subsequent steps.
+ *
+ * Each batch is independent: a failure (returned or thrown) only affects that
+ * batch. Results are collected in batch order regardless of completion order,
+ * keeping `createdSummaries` / `wikiSummaryDone` deterministic.
+ *
+ * Shared concept files (Phase 3 linking) are safe under concurrency:
+ * wiki-concept.mjs serializes per-concept mutations via inter-process lock
+ * files, so parallel batches cannot lose each other's updates.
  */
 /** @internal Exported for testing only. */
 export async function runSummarizePipeline(
@@ -513,11 +639,9 @@ export async function runSummarizePipeline(
   },
   staleFiles: string[],
 ): Promise<SummarizePipelineResult> {
-  const createdSummaries: string[] = [];
-
   if (staleFiles.length === 0) {
     log.info("no stale files, skipping subagent");
-    return { createdSummaries, wikiSummaryDone: "No stale files found." };
+    return { createdSummaries: [], wikiSummaryDone: "No stale files found." };
   }
 
   // ── Build batches ──
@@ -526,65 +650,44 @@ export async function runSummarizePipeline(
     totalFiles: staleFiles.length,
     batchCount: batches.length,
     batchSize: BATCH_SIZE,
+    maxConcurrent: MAX_CONCURRENT_BATCHES,
   });
 
-  // ── Process batches sequentially ──
-  let batchFailed = false;
-  let wikiSummaryDone = "";
-
-  try {
-    for (let i = 0; i < batches.length; i++) {
-      const batchResult = await processBatch(
-        exec,
-        batches[i],
-        i,
-        batches.length,
-      );
-
-      if (!batchResult.ok) {
-        const errorMsg = batchResult.done ?? "unknown error";
-        log.warn("wiki-summarize batch failed", {
-          batch: `${i + 1}/${batches.length}`,
-          error: errorMsg,
-        });
-
-        await sendTelegramNotification(
-          buildTelegramFailureMessage(
-            `Step 1-3 (wiki-summarize batch ${i + 1}/${batches.length})`,
-            errorMsg,
-          ),
-        ).catch((e) =>
-          log.warn("telegram notify failed", { error: String(e) }),
-        );
-        batchFailed = true;
-        // Continue with remaining batches — each batch is independent
-        continue;
-      }
-
-      if (batchResult.summaries) {
-        createdSummaries.push(...batchResult.summaries);
-      }
-      if (batchResult.done) {
-        if (wikiSummaryDone) wikiSummaryDone += " | ";
-        wikiSummaryDone += `Batch ${i + 1}: ${batchResult.done}`;
-      }
-
-      log.info("wiki-summarize batch completed", {
-        batch: `${i + 1}/${batches.length}`,
-        summariesCount: batchResult.summaries?.length ?? 0,
+  // ── Process batches with bounded concurrency ──
+  // A thrown subagent error degrades to a failed batch inside the pool
+  // (onRejected keeps the shell-level log); collected results are never lost.
+  // Concept-file writes stay safe: wiki-concept.mjs locks per concept slug.
+  const results = await runBatchesConcurrently(
+    batches,
+    MAX_CONCURRENT_BATCHES,
+    (batch, index) => processBatch(exec, batch, index, batches.length),
+    (err, index) => {
+      log.warn("wiki-summarize batch threw", {
+        batch: `${index + 1}/${batches.length}`,
+        error: errorMessage(err),
       });
-    }
-  } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err);
-    log.warn("subagent batch iteration threw", { error: errorMsg });
+    },
+  );
+
+  // ── Aggregate results (pure) → surface failures (shell) ──
+  const { createdSummaries, wikiSummaryDone, failed } =
+    aggregateBatchResults(results);
+
+  for (const f of failed) {
+    log.warn("wiki-summarize batch failed", {
+      batch: `${f.batch}/${results.length}`,
+      error: f.error,
+    });
 
     await sendTelegramNotification(
-      buildTelegramFailureMessage("Step 1-3 (wiki-summarize)", errorMsg),
+      buildTelegramFailureMessage(
+        `Step 1-3 (wiki-summarize batch ${f.batch}/${results.length})`,
+        f.error,
+      ),
     ).catch((e) => log.warn("telegram notify failed", { error: String(e) }));
-    batchFailed = true;
   }
 
-  if (batchFailed) {
+  if (failed.length > 0) {
     log.warn("wiki-summarize pipeline partially completed", {
       summariesCount: createdSummaries.length,
       note: "some batches failed, see previous warnings",

--- a/skills/knowledge-wiki/concept/lib/concept-lock.mjs
+++ b/skills/knowledge-wiki/concept/lib/concept-lock.mjs
@@ -1,0 +1,130 @@
+/**
+ * concept-lock.mjs — Inter-process lock for concept file mutations.
+ *
+ * wiki-concept.mjs mutates shared concept files with read-modify-write cycles
+ * (read the file, insert a bullet, write it back). When multiple Pi subagents
+ * run wiki-summarize batches concurrently, two agents can read the same
+ * concept file, then both write — silently dropping one agent's update
+ * (lost update / last-write-wins).
+ *
+ * This module serializes mutations of the same concept across processes via
+ * an atomic O_CREAT|O_EXCL lock file in the OS temp dir (kept out of the
+ * knowledge base repo so it never pollutes `git status`).
+ *
+ * Crash recovery:
+ * - Locks held by dead processes (PID liveness check) are stolen immediately.
+ * - Locks older than LOCK_TTL_MS are stolen even if the PID is alive
+ *   (fallback for the PID-reuse edge case).
+ * - Acquisition gives up after LOCK_WAIT_MS with a descriptive error, so a
+ *   stuck holder fails loudly instead of blocking forever.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const LOCK_TTL_MS = 60_000; // mutations are sub-second; generous TTL
+export const LOCK_WAIT_MS = 15_000; // give up waiting after this long
+export const LOCK_RETRY_MS = 50;
+
+/** Deterministic per-knowledge-base lock directory (hash of concepts dir). */
+export function conceptLockDir(conceptsDir) {
+  const hash = fnv1a(conceptsDir).toString(36);
+  return path.join(os.tmpdir(), "pi-kit-concept-locks", hash);
+}
+
+/** Path of the lock file guarding mutations of a concept slug. */
+export function conceptLockPath(conceptsDir, slug) {
+  const safeSlug = slug.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return path.join(conceptLockDir(conceptsDir), `${safeSlug}.lock`);
+}
+
+/**
+ * Run `fn` while holding an exclusive lock for `lockPath`.
+ *
+ * Returns fn's return value. Throws if the lock cannot be acquired within
+ * `opts.waitMs` (default LOCK_WAIT_MS). `fn` may be sync or async.
+ *
+ * Note: `fn` must not call `process.exit` — a hard exit skips the release
+ * path; the leftover lock is recovered on the next attempt via the
+ * dead-PID staleness check, but relying on that in normal flow is wasteful.
+ */
+export async function withConceptLock(lockPath, fn, opts = {}) {
+  const waitMs = opts.waitMs ?? LOCK_WAIT_MS;
+  const retryMs = opts.retryMs ?? LOCK_RETRY_MS;
+  const ttlMs = opts.ttlMs ?? LOCK_TTL_MS;
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  const deadline = Date.now() + waitMs;
+
+  while (true) {
+    try {
+      const fd = fs.openSync(lockPath, "wx");
+      try {
+        fs.writeSync(fd, `${process.pid}:${Date.now()}\n`);
+      } finally {
+        fs.closeSync(fd);
+      }
+      break;
+    } catch (err) {
+      if (err.code !== "EEXIST") throw err;
+      if (isStale(lockPath, ttlMs)) {
+        try {
+          fs.unlinkSync(lockPath);
+        } catch {
+          // Another process stole it first — retry the acquire.
+        }
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out after ${waitMs}ms waiting for concept lock: ${lockPath}`,
+        );
+      }
+      await sleep(retryMs);
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    try {
+      fs.unlinkSync(lockPath);
+    } catch {
+      // Lock already removed (e.g. stolen after TTL) — nothing to do.
+    }
+  }
+}
+
+// ── Private ───────────────────────────────────────────────────────────────
+
+function isStale(lockPath, ttlMs) {
+  try {
+    const content = fs.readFileSync(lockPath, "utf8");
+    const pid = Number.parseInt(content.split(":")[0], 10);
+    if (Number.isInteger(pid) && pid > 0) {
+      try {
+        process.kill(pid, 0);
+      } catch {
+        return true; // holder process is dead
+      }
+    }
+    const stat = fs.statSync(lockPath);
+    return Date.now() - stat.mtimeMs > ttlMs;
+  } catch {
+    return true; // unreadable lock — treat as stale and retry
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** FNV-1a 32-bit hash — stable across processes, no imports needed. */
+function fnv1a(str) {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}

--- a/skills/knowledge-wiki/concept/lib/concept-lock.test.ts
+++ b/skills/knowledge-wiki/concept/lib/concept-lock.test.ts
@@ -1,0 +1,129 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  conceptLockDir,
+  conceptLockPath,
+  withConceptLock,
+} from "./concept-lock.mjs";
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "concept-lock-test-"));
+}
+
+describe("conceptLockPath", () => {
+  it("derives a stable per-knowledge-base lock dir", () => {
+    expect(conceptLockDir("/a/notes/Wiki/Concepts")).toBe(
+      conceptLockDir("/a/notes/Wiki/Concepts"),
+    );
+    expect(conceptLockDir("/a/notes/Wiki/Concepts")).not.toBe(
+      conceptLockDir("/b/notes/Wiki/Concepts"),
+    );
+  });
+
+  it("sanitizes slugs into safe lock filenames", () => {
+    const lockPath = conceptLockPath("/kb/Wiki/Concepts", "Foo/Bar Baz");
+    expect(path.basename(lockPath)).toBe("Foo_Bar_Baz.lock");
+  });
+});
+
+describe("withConceptLock", () => {
+  it("creates and removes the lock file, returning fn's result", async () => {
+    const lockPath = path.join(tmpDir(), "x.lock");
+    const result = await withConceptLock(lockPath, () => 42);
+    expect(result).toBe(42);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("supports async fns and preserves their result", async () => {
+    const lockPath = path.join(tmpDir(), "x.lock");
+    const result = await withConceptLock(lockPath, async () => "async-ok");
+    expect(result).toBe("async-ok");
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("releases the lock when fn throws", async () => {
+    const lockPath = path.join(tmpDir(), "x.lock");
+    await expect(
+      withConceptLock(lockPath, () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("serializes concurrent mutations — no lost updates", async () => {
+    const lockPath = path.join(tmpDir(), "x.lock");
+    let inside = 0;
+    let maxInside = 0;
+    let counter = 0;
+
+    await Promise.all(
+      Array.from({ length: 5 }, () =>
+        withConceptLock(lockPath, async () => {
+          inside++;
+          maxInside = Math.max(maxInside, inside);
+          const seen = counter; // simulate read-modify-write
+          await new Promise((r) => setTimeout(r, 10));
+          counter = seen + 1;
+          inside--;
+        }),
+      ),
+    );
+
+    expect(counter).toBe(5); // every increment survived
+    expect(maxInside).toBe(1); // strictly serialized
+  });
+
+  it("steals a lock left by a dead process", async () => {
+    const lockPath = path.join(tmpDir(), "x.lock");
+    const dead = spawnSync(process.execPath, ["-e", ""]); // exited → dead pid
+    fs.writeFileSync(lockPath, `${dead.pid}:${Date.now()}\n`);
+
+    const result = await withConceptLock(lockPath, () => "ok");
+    expect(result).toBe("ok");
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("waits for a live holder and proceeds after it releases", async () => {
+    const lockPath = path.join(tmpDir(), "x.lock");
+    fs.writeFileSync(lockPath, `${process.pid}:${Date.now()}\n`);
+    const timer = setTimeout(() => fs.unlinkSync(lockPath), 30);
+
+    try {
+      const result = await withConceptLock(lockPath, () => "ok", {
+        waitMs: 2_000,
+        retryMs: 5,
+      });
+      expect(result).toBe("ok");
+    } finally {
+      clearTimeout(timer);
+      if (fs.existsSync(lockPath)) fs.unlinkSync(lockPath);
+    }
+  });
+
+  it("throws when the lock cannot be acquired in time", async () => {
+    const lockPath = path.join(tmpDir(), "x.lock");
+    fs.writeFileSync(lockPath, `${process.pid}:${Date.now()}\n`);
+
+    await expect(
+      withConceptLock(lockPath, () => "never", { waitMs: 50, retryMs: 5 }),
+    ).rejects.toThrow(/Timed out after 50ms/);
+  });
+
+  it("steals locks older than the TTL even if the pid is alive", async () => {
+    const lockPath = path.join(tmpDir(), "x.lock");
+    // Live pid (this process) but an old mtime — PID-reuse fallback path.
+    fs.writeFileSync(lockPath, `${process.pid}:${Date.now() - 10_000}\n`);
+    const old = new Date(Date.now() - 10_000);
+    fs.utimesSync(lockPath, old, old);
+
+    const result = await withConceptLock(lockPath, () => "ok", {
+      ttlMs: 5_000,
+    });
+    expect(result).toBe("ok");
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+});

--- a/skills/knowledge-wiki/concept/wiki-concept.mjs
+++ b/skills/knowledge-wiki/concept/wiki-concept.mjs
@@ -14,12 +14,17 @@
  *   node scripts/wiki/wiki-concept.mjs delete-connected-concept <slug> <linked-slug>
  *
  * --base-path can be added at any position to override the KNOWLEDGE_DIR.
+ *
+ * All mutating subcommands serialize per concept via an inter-process lock
+ * (./lib/concept-lock.mjs), so concurrent invocations — e.g. parallel
+ * wiki-summarize subagent batches — cannot lose each other's updates.
  */
 
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildConceptContent } from "./lib/concept-content.mjs";
+import { conceptLockPath, withConceptLock } from "./lib/concept-lock.mjs";
 import {
   CONCEPTS_DIR,
   conceptFullPath,
@@ -56,7 +61,7 @@ function writeConcept(slug, content) {
 
 // --- Subcommands ---
 
-function cmdCreate(args) {
+async function cmdCreate(args) {
   const slug = args[0];
   const displayName = args[1];
   if (!slug || !displayName) {
@@ -74,38 +79,43 @@ function cmdCreate(args) {
   const icon = iconIdx !== -1 && args[iconIdx + 1] ? args[iconIdx + 1] : "note";
   const tags = tagsIdx !== -1 && args[tagsIdx + 1] ? args[tagsIdx + 1] : "[]";
 
-  if (fs.existsSync(conceptFullPath(slug))) {
-    console.error(`Concept file already exists: ${conceptRelPath(slug)}`);
-    console.error(
-      "Use insert-source / insert-connected-concept to modify existing concepts.",
-    );
-    process.exit(1);
-  }
+  // The existsSync check and write must be atomic: two concurrent creators
+  // for the same slug would otherwise both pass the check and clobber each
+  // other's file (last-write-wins).
+  await withConceptLock(conceptLockPath(CONCEPTS_DIR, slug), () => {
+    if (fs.existsSync(conceptFullPath(slug))) {
+      console.error(`Concept file already exists: ${conceptRelPath(slug)}`);
+      console.error(
+        "Use insert-source / insert-connected-concept to modify existing concepts.",
+      );
+      process.exit(1);
+    }
 
-  fs.mkdirSync(CONCEPTS_DIR, { recursive: true });
+    fs.mkdirSync(CONCEPTS_DIR, { recursive: true });
 
-  // Read body content from stdin when data is piped (non-TTY stdin).
-  // This allows the caller to pipe body text: `echo "body" | node ... create ...`
-  // or redirect from a temp file: `node ... create ... < temp-body-file`
-  let body = "";
-  if (!process.stdin.isTTY) {
-    const piped = fs.readFileSync(0, "utf8").trimEnd();
-    if (piped) body = piped;
-  }
+    // Read body content from stdin when data is piped (non-TTY stdin).
+    // This allows the caller to pipe body text: `echo "body" | node ... create ...`
+    // or redirect from a temp file: `node ... create ... < temp-body-file`
+    let body = "";
+    if (!process.stdin.isTTY) {
+      const piped = fs.readFileSync(0, "utf8").trimEnd();
+      if (piped) body = piped;
+    }
 
-  const content = buildConceptContent({
-    displayName,
-    type,
-    icon,
-    tags,
-    body,
+    const content = buildConceptContent({
+      displayName,
+      type,
+      icon,
+      tags,
+      body,
+    });
+
+    fs.writeFileSync(conceptFullPath(slug), content, "utf8");
+    console.log(conceptRelPath(slug));
   });
-
-  fs.writeFileSync(conceptFullPath(slug), content, "utf8");
-  console.log(conceptRelPath(slug));
 }
 
-function cmdInsertSource(args) {
+async function cmdInsertSource(args) {
   const [slug, summaryPath] = args;
   if (!slug || !summaryPath) {
     console.error(
@@ -114,26 +124,30 @@ function cmdInsertSource(args) {
     process.exit(1);
   }
 
-  const summaryFile = path.join(KNOWLEDGE_DIR, `${summaryPath}.md`);
-  if (!fs.existsSync(summaryFile)) {
-    console.error(`Error: summary file not found: ${summaryPath}.md`);
-    process.exit(1);
-  }
+  // Read-modify-write must be atomic: two concurrent inserters would both
+  // read the pre-insert state and the last write would drop the other's link.
+  await withConceptLock(conceptLockPath(CONCEPTS_DIR, slug), () => {
+    const summaryFile = path.join(KNOWLEDGE_DIR, `${summaryPath}.md`);
+    if (!fs.existsSync(summaryFile)) {
+      console.error(`Error: summary file not found: ${summaryPath}.md`);
+      process.exit(1);
+    }
 
-  const link = `[[${summaryPath}]]`;
-  const content = readConcept(slug);
+    const link = `[[${summaryPath}]]`;
+    const content = readConcept(slug);
 
-  if (sectionContains(content, "Sources", link)) {
-    console.log(`Already present in ${slug}: ${summaryPath}`);
-    return;
-  }
+    if (sectionContains(content, "Sources", link)) {
+      console.log(`Already present in ${slug}: ${summaryPath}`);
+      return;
+    }
 
-  const updated = insertBulletInSection(content, "Sources", `- ${link}`);
-  writeConcept(slug, updated);
-  console.log(`Inserted source into ${slug}.`);
+    const updated = insertBulletInSection(content, "Sources", `- ${link}`);
+    writeConcept(slug, updated);
+    console.log(`Inserted source into ${slug}.`);
+  });
 }
 
-function cmdDeleteSource(args) {
+async function cmdDeleteSource(args) {
   const [slug, summaryPath] = args;
   if (!slug || !summaryPath) {
     console.error(
@@ -142,24 +156,26 @@ function cmdDeleteSource(args) {
     process.exit(1);
   }
 
-  const link = `[[${summaryPath}]]`;
-  const content = readConcept(slug);
-  const { content: updated, found } = deleteBulletFromSection(
-    content,
-    "Sources",
-    (line) => line.includes(link),
-  );
+  await withConceptLock(conceptLockPath(CONCEPTS_DIR, slug), () => {
+    const link = `[[${summaryPath}]]`;
+    const content = readConcept(slug);
+    const { content: updated, found } = deleteBulletFromSection(
+      content,
+      "Sources",
+      (line) => line.includes(link),
+    );
 
-  if (!found) {
-    console.log(`Not found in ${slug}: ${summaryPath}`);
-    return;
-  }
+    if (!found) {
+      console.log(`Not found in ${slug}: ${summaryPath}`);
+      return;
+    }
 
-  writeConcept(slug, updated);
-  console.log(`Deleted source from ${slug}.`);
+    writeConcept(slug, updated);
+    console.log(`Deleted source from ${slug}.`);
+  });
 }
 
-function cmdInsertConnectedConcept(args) {
+async function cmdInsertConnectedConcept(args) {
   const [slug, linkedSlug, displayName] = args;
   if (!slug || !linkedSlug || !displayName) {
     console.error(
@@ -173,31 +189,33 @@ function cmdInsertConnectedConcept(args) {
     return;
   }
 
-  const link = `[[Wiki/Concepts/${linkedSlug}|${displayName}]]`;
-  const content = readConcept(slug);
+  await withConceptLock(conceptLockPath(CONCEPTS_DIR, slug), () => {
+    const link = `[[Wiki/Concepts/${linkedSlug}|${displayName}]]`;
+    const content = readConcept(slug);
 
-  if (
-    sectionContains(
+    if (
+      sectionContains(
+        content,
+        "Connected Concepts",
+        `[[Wiki/Concepts/${linkedSlug}|`,
+      )
+    ) {
+      console.log(`Already present in ${slug}: ${linkedSlug}`);
+      return;
+    }
+
+    const updated = insertBulletInSection(
       content,
       "Connected Concepts",
-      `[[Wiki/Concepts/${linkedSlug}|`,
-    )
-  ) {
-    console.log(`Already present in ${slug}: ${linkedSlug}`);
-    return;
-  }
-
-  const updated = insertBulletInSection(
-    content,
-    "Connected Concepts",
-    `- ${link}`,
-    { insertBefore: "Sources" },
-  );
-  writeConcept(slug, updated);
-  console.log(`Inserted connected concept into ${slug}.`);
+      `- ${link}`,
+      { insertBefore: "Sources" },
+    );
+    writeConcept(slug, updated);
+    console.log(`Inserted connected concept into ${slug}.`);
+  });
 }
 
-function cmdDeleteConnectedConcept(args) {
+async function cmdDeleteConnectedConcept(args) {
   const [slug, linkedSlug] = args;
   if (!slug || !linkedSlug) {
     console.error(
@@ -206,22 +224,24 @@ function cmdDeleteConnectedConcept(args) {
     process.exit(1);
   }
 
-  const linkWithAlias = `[[Wiki/Concepts/${linkedSlug}|`;
-  const linkBare = `[[Wiki/Concepts/${linkedSlug}]]`;
-  const content = readConcept(slug);
-  const { content: updated, found } = deleteBulletFromSection(
-    content,
-    "Connected Concepts",
-    (line) => line.includes(linkWithAlias) || line.includes(linkBare),
-  );
+  await withConceptLock(conceptLockPath(CONCEPTS_DIR, slug), () => {
+    const linkWithAlias = `[[Wiki/Concepts/${linkedSlug}|`;
+    const linkBare = `[[Wiki/Concepts/${linkedSlug}]]`;
+    const content = readConcept(slug);
+    const { content: updated, found } = deleteBulletFromSection(
+      content,
+      "Connected Concepts",
+      (line) => line.includes(linkWithAlias) || line.includes(linkBare),
+    );
 
-  if (!found) {
-    console.log(`Not found in ${slug}: ${linkedSlug}`);
-    return;
-  }
+    if (!found) {
+      console.log(`Not found in ${slug}: ${linkedSlug}`);
+      return;
+    }
 
-  writeConcept(slug, updated);
-  console.log(`Deleted connected concept from ${slug}.`);
+    writeConcept(slug, updated);
+    console.log(`Deleted connected concept from ${slug}.`);
+  });
 }
 
 // --- Dispatch ---
@@ -234,27 +254,39 @@ if (
 ) {
   const [, , subcommand, ...rest] = process.argv;
 
-  switch (subcommand) {
-    case "create":
-      cmdCreate(rest);
-      break;
-    case "insert-source":
-      cmdInsertSource(rest);
-      break;
-    case "delete-source":
-      cmdDeleteSource(rest);
-      break;
-    case "insert-connected-concept":
-      cmdInsertConnectedConcept(rest);
-      break;
-    case "delete-connected-concept":
-      cmdDeleteConnectedConcept(rest);
-      break;
-    default:
-      console.error(`Unknown subcommand: ${subcommand}`);
-      console.error(
-        "Subcommands: create, insert-source, delete-source, insert-connected-concept, delete-connected-concept",
-      );
-      process.exit(1);
-  }
+  // Mutating commands are async (they hold the concept lock); a hard
+  // process.exit inside a lock leaves the lock behind, so top-level errors
+  // (e.g. lock acquisition timeout) exit via the catch below.
+  const run = (async () => {
+    switch (subcommand) {
+      case "create":
+        await cmdCreate(rest);
+        break;
+      case "insert-source":
+        await cmdInsertSource(rest);
+        break;
+      case "delete-source":
+        await cmdDeleteSource(rest);
+        break;
+      case "insert-connected-concept":
+        await cmdInsertConnectedConcept(rest);
+        break;
+      case "delete-connected-concept":
+        await cmdDeleteConnectedConcept(rest);
+        break;
+      default:
+        console.error(`Unknown subcommand: ${subcommand}`);
+        console.error(
+          "Subcommands: create, insert-source, delete-source, insert-connected-concept, delete-connected-concept",
+        );
+        process.exit(1);
+    }
+  })();
+
+  run.catch((err) => {
+    console.error(
+      `wiki-concept: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  });
 }


### PR DESCRIPTION


- Bound subagent batch concurrency to MAX_CONCURRENT_BATCHES (3) with a per-batch 10-minute timeout, replacing the sequential loop; results are collected in batch order regardless of completion order
- Degrade thrown batch errors to failed results via runBatchesConcurrently so a crashing subagent never aborts the whole pipeline
- Extract pure aggregateBatchResults (createdSummaries / wikiSummaryDone / failed) from the shell, which now only logs and notifies for failures
- Serialize concept-file mutations per slug with an inter-process lock (new concept-lock.mjs: PID liveness check, TTL, wait timeout) so parallel batches cannot lose each other's updates
- Make wiki-concept.mjs mutating subcommands async and lock-guarded
- Add tests for the concurrency cap, out-of-order completion, rejection handling, and lock serialization/staleness