### PR TITLE
feat(knowledge-wiki): split index into per-year DailyNotes shards

### DIFF
--- a/extensions/scheduled-tasks/tasks/knowledge-wiki-daily.test.ts
+++ b/extensions/scheduled-tasks/tasks/knowledge-wiki-daily.test.ts
@@ -6,6 +6,7 @@ import {
   buildSubagentPrompt,
   parseResultJson,
   runQmdStep,
+  runShardMigration,
   runSummarizePipeline,
 } from "./knowledge-wiki-daily.js";
 
@@ -40,6 +41,8 @@ describe("buildSubagentPrompt", () => {
     expect(result).toContain("<cwd>");
     expect(result).toContain("<path-to-wiki-summary.mjs>");
     expect(result).toContain("<path-to-wiki-concept.mjs>");
+    expect(result).toContain("<path-to-wiki-index.mjs>");
+    expect(result).toContain("wiki-index.mjs path");
   });
 
   it("should mention the 4-phase workflow", () => {
@@ -285,6 +288,46 @@ describe("runQmdStep", () => {
     });
 
     expect(process.env[key]).toBeUndefined();
+  });
+});
+
+// ── runShardMigration ─────────────────────────────────
+
+describe("runShardMigration", () => {
+  it("runs split-daily-shards with the index script and base path", async () => {
+    const exec = {
+      exec: vi.fn().mockResolvedValue({
+        code: 0,
+        stdout:
+          '{"years": {"2026": 3}, "kept": 2, "backup": "index.md.bak-20260101"}',
+        stderr: "",
+      }),
+    };
+
+    await runShardMigration(exec);
+
+    expect(exec.exec).toHaveBeenCalledWith("node", [
+      expect.stringContaining("knowledge-wiki"),
+      "split-daily-shards",
+      "--base-path",
+      expect.stringContaining("notes"),
+    ]);
+  });
+
+  it("swallows a non-zero exit code", async () => {
+    const exec = {
+      exec: vi.fn().mockResolvedValue({ code: 1, stdout: "", stderr: "boom" }),
+    };
+
+    await expect(runShardMigration(exec)).resolves.toBeUndefined();
+  });
+
+  it("swallows a thrown error", async () => {
+    const exec = {
+      exec: vi.fn().mockRejectedValue(new Error("spawn failed")),
+    };
+
+    await expect(runShardMigration(exec)).resolves.toBeUndefined();
   });
 });
 

--- a/extensions/scheduled-tasks/tasks/knowledge-wiki-daily.ts
+++ b/extensions/scheduled-tasks/tasks/knowledge-wiki-daily.ts
@@ -2,6 +2,7 @@
  * knowledge-wiki-daily.ts — Daily knowledge base maintenance task.
  *
  * Pipeline:
+ *   Step 0:   split-daily-shards — move DailyNotes entries into Wiki/index-<year>.md (idempotent)
  *   Pre-step: run wiki-summary list-stale to get file list
  *   Step 1-3: Pi subagent with --prompt-template prompts/wiki-summarize.md
  *             - Phase 1: list-stale (from prompt)
@@ -42,6 +43,14 @@ const CONCEPT_SCRIPT = join(
   "knowledge-wiki",
   "concept",
   "wiki-concept.mjs",
+);
+
+const INDEX_SCRIPT = join(
+  PI_KIT_DIR,
+  "skills",
+  "knowledge-wiki",
+  "state",
+  "wiki-index.mjs",
 );
 
 const PROMPT_TEMPLATE_PATH = join(PI_KIT_DIR, "prompts", "wiki-summarize.md");
@@ -97,10 +106,12 @@ export function buildSubagentPrompt(staleFiles: string[]): string {
     `Knowledge base root: ${KNOWLEDGE_DIR}`,
     `wiki-summary.mjs path: ${SUMMARY_SCRIPT}`,
     `wiki-concept.mjs path: ${CONCEPT_SCRIPT}`,
+    `wiki-index.mjs path: ${INDEX_SCRIPT}`,
     "",
     "Replace `<cwd>` with the knowledge base root above for all `--base-path` arguments.",
     "Replace `<path-to-wiki-summary.mjs>` with the absolute path above when running node commands.",
     "Replace `<path-to-wiki-concept.mjs>` with the absolute path above when running node commands.",
+    "Replace `<path-to-wiki-index.mjs>` with the absolute path above when running node commands.",
     "",
     `## Stale Files (${staleFiles.length} total)`,
     "",
@@ -483,6 +494,52 @@ export async function runQmdStep(
 // ── Shell: run the wiki-summarize pipeline across all batches ────────────
 
 /**
+ * Run the one-time `split-daily-shards` migration: move DailyNotes summaries
+ * out of the main index into per-year shard files (Wiki/index-<year>.md).
+ *
+ * Idempotent — once the main index holds no DailyNotes entries the script
+ * reports a no-op. Running it on every daily run keeps knowledge bases that
+ * predate the shard layout from splitting DailyNotes across the main index
+ * and shards as new `upsert-summary` calls route into shards.
+ *
+ * Pure IO shell — no decision logic. Failures are logged and swallowed: the
+ * summarize pipeline still works against an unmigrated index, so a broken
+ * migration must not block the daily run.
+ */
+/** @internal Exported for testing only. */
+export async function runShardMigration(exec: {
+  exec: (
+    cmd: string,
+    args?: string[],
+  ) => Promise<{ code: number; stdout: string; stderr: string }>;
+}): Promise<void> {
+  log.info("Step 0: split-daily-shards migration");
+  try {
+    const result = await exec.exec("node", [
+      INDEX_SCRIPT,
+      "split-daily-shards",
+      "--base-path",
+      KNOWLEDGE_DIR,
+    ]);
+    if (result.code !== 0) {
+      log.warn("split-daily-shards failed", {
+        exitCode: result.code,
+        stderr: result.stderr.slice(0, 500),
+      });
+      return;
+    }
+    const stdout = result.stdout.trim();
+    if (stdout) {
+      log.info("split-daily-shards output", { stdout: stdout.slice(0, 500) });
+    }
+  } catch (err) {
+    log.warn("split-daily-shards threw", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
  * Result of the wiki-summarize pipeline.
  */
 interface SummarizePipelineResult {
@@ -607,6 +664,9 @@ export default defineTask({
     "每日知识库维护：过期摘要重新生成、概念自动链接、qmd 索引和向量嵌入更新",
 
   handler: async (exec) => {
+    // ── Step 0: split DailyNotes into per-year shards (idempotent migration) ──
+    await runShardMigration(exec);
+
     // ── Pre-step: list stale files ──
     log.info("Pre-step: list-stale");
     const staleFiles = await listStaleFiles(exec);

--- a/prompts/wiki-summarize.md
+++ b/prompts/wiki-summarize.md
@@ -12,19 +12,19 @@ Default to Chinese unless the user explicitly asks for another language.
 
 - **No argument** (`$1` is empty): run `list-stale` on the knowledge base and process all stale files
 - **Single file path** (`$1` is a relative path like `Notes/Foo.md`): process only that specific file, even if it's not stale
-- The knowledge base root is the current working directory (where `Wiki/` lives)
+- The knowledge base root is the current working directory (where `Wiki/` lives); when run from the scheduled task, use the knowledge base root from the task configuration as `<cwd>`
 
 ## Dependencies
 
-Two skill scripts in this project's `.pi/skills/`:
+Three skill scripts in the pi-kit repo under `skills/knowledge-wiki/`:
 
 | Script | Location | Commands used |
 |--------|----------|---------------|
-| `wiki-summary.mjs` | `.pi/skills/knowledge-wiki-summary/wiki-summary.mjs` | `list-stale`, `create`, `insert-concept` |
-| `wiki-concept.mjs` | `.pi/skills/knowledge-wiki-concept/wiki-concept.mjs` | `create` (with `--tags` + stdin body), `insert-source` |
-| `wiki-index.mjs` (state) | `.pi/skills/knowledge-wiki-state/wiki-index.mjs` | `upsert-summary` |
+| `wiki-summary.mjs` | `skills/knowledge-wiki/summary/wiki-summary.mjs` | `list-stale`, `create`, `insert-concept` |
+| `wiki-concept.mjs` | `skills/knowledge-wiki/concept/wiki-concept.mjs` | `create` (with `--tags` + stdin body), `insert-source` |
+| `wiki-index.mjs` (state) | `skills/knowledge-wiki/state/wiki-index.mjs` | `upsert-summary` |
 
-Resolve all relative paths (`./*.mjs`, `./lib/*.mjs`) relative to the source skill directory (same as `SKILL.md`). Pass `--base-path <cwd>` to every command.
+The placeholders `<path-to-wiki-summary.mjs>`, `<path-to-wiki-concept.mjs>`, `<path-to-wiki-index.mjs>`, and `<cwd>` are filled in by the task configuration (see the injected `## Task Configuration` section). Use those absolute paths exactly. Pass `--base-path <cwd>` to every command.
 
 ## Workflow
 
@@ -58,7 +58,7 @@ For each stale source file in the list (or the single file from `$1`):
 
    Derive tags from the file's frontmatter `tags` field and the content topics. Use the same tag convention as existing summaries (e.g. `[cpp/learning, cpp/11]`, `[ebpf/learning]`).
 
-4. **Update the index** — Register or update the summary entry in `Wiki/index.md`:
+4. **Update the index** — Register or update the summary entry in the index:
 
    Derive the summary's rel-path by stripping the `Wiki/Summaries/` prefix and the `.md` extension from the output path printed by the `create` command.
 
@@ -70,7 +70,7 @@ For each stale source file in the list (or the single file from `$1`):
    node <path-to-wiki-index.mjs> upsert-summary "{rel-path}" "{one-line description}" --base-path <cwd>
    ```
 
-   The sumary file will have a path like `Wiki/Summaries/...` — derive `{rel-path}` by removing the `Wiki/Summaries/` prefix and the `.md` extension.
+   The summary file will have a path like `Wiki/Summaries/...` — derive `{rel-path}` by removing the `Wiki/Summaries/` prefix and the `.md` extension. `upsert-summary` routes DailyNotes summaries (`Calendar/DailyNotes/<year>/...`) into `Wiki/index-<year>.md` and everything else into `Wiki/index.md` — no manual routing needed.
 
 ### Phase 3: Link concepts
 
@@ -154,10 +154,10 @@ End your response with a single JSON object on its own line. Use this exact sche
 
 ## Notes
 
-- The path to `wiki-summary.mjs` is `.pi/skills/knowledge-wiki-summary/wiki-summary.mjs`
-- The path to `wiki-concept.mjs` is `.pi/skills/knowledge-wiki-concept/wiki-concept.mjs`
-- The path to `wiki-index.mjs` (state) is `.pi/skills/knowledge-wiki-state/wiki-index.mjs`
-- Always pass `--base-path` as the current working directory so the scripts resolve the knowledge base root correctly
+- The scripts live in the pi-kit repo: `skills/knowledge-wiki/summary/wiki-summary.mjs`, `skills/knowledge-wiki/concept/wiki-concept.mjs`, `skills/knowledge-wiki/state/wiki-index.mjs`
+- Use the absolute paths injected by the task configuration for `<path-to-wiki-summary.mjs>`, `<path-to-wiki-concept.mjs>`, `<path-to-wiki-index.mjs>`
+- Always pass `--base-path <cwd>` (the knowledge base root from the task configuration) so the scripts resolve the knowledge base root correctly
+- If the main index (`Wiki/index.md`) still contains `Calendar/DailyNotes/...` entries from before the shard layout, run `node <path-to-wiki-index.mjs> split-daily-shards --base-path <cwd>` once to move them into per-year shards (`Wiki/index-<year>.md`). It is idempotent; the scheduled task runs it automatically at the start of every run.
 - Use `--tags` with the bracket format like `[tag1, tag2]` (must be valid JSON array)
 - The `insert-concept` command reads all fields from stdin when `-` is passed as the first argument, with one field per line: summary-rel-path, slug, display-name, description (the last field spans the rest and is trimmed)
 - For `insert-source`, the summary path is without the `.summary.md` suffix (e.g. `Wiki/Summaries/Notes/Foo.summary`)

--- a/skills/knowledge-wiki/cluster/lib/graph.mjs
+++ b/skills/knowledge-wiki/cluster/lib/graph.mjs
@@ -33,7 +33,8 @@ function findWikiFiles(dir, knowledgeDir, results = []) {
     } else if (
       entry.isFile() &&
       entry.name.endsWith(".md") &&
-      entry.name !== "index.md"
+      entry.name !== "index.md" &&
+      !/^index-\d{4}\.md$/.test(entry.name)
     ) {
       results.push(
         path.relative(knowledgeDir, fullPath).replaceAll(path.sep, "/"),

--- a/skills/knowledge-wiki/enrich/lib/graph.mjs
+++ b/skills/knowledge-wiki/enrich/lib/graph.mjs
@@ -33,7 +33,8 @@ function findWikiFiles(dir, knowledgeDir, results = []) {
     } else if (
       entry.isFile() &&
       entry.name.endsWith(".md") &&
-      entry.name !== "index.md"
+      entry.name !== "index.md" &&
+      !/^index-\d{4}\.md$/.test(entry.name)
     ) {
       results.push(
         path.relative(knowledgeDir, fullPath).replaceAll(path.sep, "/"),

--- a/skills/knowledge-wiki/enrich/wiki-index.mjs
+++ b/skills/knowledge-wiki/enrich/wiki-index.mjs
@@ -1,13 +1,20 @@
 /**
  * wiki-index.mjs
  *
- * Reads and writes Wiki/index.md.
+ * Reads and writes the knowledge base index files:
+ *   - Wiki/index.md             (main index: Archive + Concepts + Summaries)
+ *   - Wiki/index-<year>.md      (per-year DailyNotes shards)
+ *
+ * DailyNotes summaries are routed by path year into their shard:
+ *   Wiki/Summaries/Calendar/DailyNotes/<year>/... → Wiki/index-<year>.md
+ * Everything else (Notes/, Concepts, non-year DailyNotes entries) → Wiki/index.md
+ *
  * Skills should call this instead of reading the whole file and writing it back.
  *
  * Usage:
  *   node scripts/wiki/wiki-index.mjs sort
  *   node scripts/wiki/wiki-index.mjs read-concepts
- *   node scripts/wiki/wiki-index.mjs read-summaries
+ *   node scripts/wiki/wiki-index.mjs read-summaries [--all]
  *   node scripts/wiki/wiki-index.mjs upsert-concept <slug> "<display-name>" "<description>"
  *   node scripts/wiki/wiki-index.mjs delete-concept <slug>
  *   node scripts/wiki/wiki-index.mjs upsert-summary "<rel-path>" "<description>"
@@ -15,11 +22,13 @@
  *   node scripts/wiki/wiki-index.mjs find-missing-summaries
  *   node scripts/wiki/wiki-index.mjs find-missing-concepts
  *   node scripts/wiki/wiki-index.mjs delete-dead-links
+ *   node scripts/wiki/wiki-index.mjs split-daily-shards
  *
  * --base-path can be added at any position to override the KNOWLEDGE_DIR.
  */
 
 import {
+  copyFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -29,7 +38,12 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { INDEX_PATH, KNOWLEDGE_DIR, SUMMARIES_DIR } from "./lib/paths.mjs";
+import {
+  INDEX_PATH,
+  KNOWLEDGE_DIR,
+  SUMMARIES_DIR,
+  WIKI_DIR,
+} from "./lib/paths.mjs";
 import { getBulletsFromSection } from "./lib/sections.mjs";
 
 process.stdout.on("error", (err) => {
@@ -39,21 +53,146 @@ process.stdout.on("error", (err) => {
 const CONCEPT_RE = /^- \[\[Wiki\/Concepts\/([^|]+)\|([^\]]+)\]\] — (.+)$/;
 const SUMMARY_RE = /^- \[\[Wiki\/Summaries\/((?:[^\]]|\](?!\]))+)\]\] — (.+)$/;
 
-function parseIndex() {
-  if (!existsSync(INDEX_PATH)) {
-    return { concepts: [], summaries: [] };
+/** DailyNotes summary rel-paths that belong in a per-year shard. */
+const DAILY_SHARD_RE = /^Calendar\/DailyNotes\/(\d{4})\//;
+
+// ── Pure: shard routing & bullet editing ──────────────────────────────────
+
+/**
+ * Route a summary rel-path to its index target.
+ *
+ * Pure — value in / value out. Testable with table tests.
+ *
+ * @param relPath - Summary rel-path (e.g. `Calendar/DailyNotes/2026/2026-07-06`
+ *                  or `Notes/redis`).
+ * @returns `{ type: "shard", year }` for DailyNotes paths with a 4-digit year
+ *          subdirectory; `{ type: "main" }` for everything else (Notes/,
+ *          Concepts, or DailyNotes entries without a year subdirectory).
+ */
+export function resolveIndexTarget(relPath) {
+  const m = DAILY_SHARD_RE.exec(relPath);
+  return m ? { type: "shard", year: m[1] } : { type: "main" };
+}
+
+/**
+ * Absolute path of a per-year shard index file.
+ *
+ * `wikiDir` defaults to the module-resolved Wiki/ directory; callers (and
+ * tests) can pass an explicit wiki directory to avoid import-time
+ * environment coupling.
+ */
+export function shardIndexPath(year, wikiDir = WIKI_DIR) {
+  return path.join(wikiDir, `index-${year}.md`);
+}
+
+/**
+ * Years of all existing shard files (`Wiki/index-<year>.md`), sorted ascending.
+ * Used to render the Archive section and to iterate shards for lint/sort.
+ */
+export function listShardYears(wikiDir = WIKI_DIR) {
+  if (!existsSync(wikiDir)) return [];
+  const years = [];
+  for (const entry of readdirSync(wikiDir, { withFileTypes: true })) {
+    const m = /^index-(\d{4})\.md$/.exec(entry.name);
+    if (entry.isFile() && m) years.push(m[1]);
+  }
+  return years.sort((a, b) => a - b);
+}
+
+/**
+ * Partition summary bullets into per-year shard buckets and main-index kept lines.
+ *
+ * Pure — value in / value out, no IO. Testable with table tests.
+ *
+ * @param summaryLines - Summary bullets from the main index's `## Summaries` section.
+ * @returns `{ shards: Map<year, bullet[]>, kept: bullet[] }`.
+ */
+export function partitionShardLines(summaryLines) {
+  const shards = new Map();
+  const kept = [];
+  for (const line of summaryLines) {
+    const m = DAILY_SHARD_RE.exec(SUMMARY_RE.exec(line)?.[1] ?? "");
+    if (m) {
+      if (!shards.has(m[1])) shards.set(m[1], []);
+      shards.get(m[1]).push(line);
+    } else {
+      kept.push(line);
+    }
+  }
+  return { shards, kept };
+}
+
+/**
+ * Insert or update a summary bullet in a list of summary lines.
+ *
+ * Pure — returns a new array, does not mutate the input.
+ *
+ * @param lines - Existing summary bullets.
+ * @param relPath - Summary rel-path to match.
+ * @param newLine - Bullet to insert or replace with.
+ * @returns `{ lines, action: "inserted" | "updated" }`.
+ */
+export function upsertBullet(lines, relPath, newLine) {
+  const idx = lines.findIndex((l) => SUMMARY_RE.exec(l)?.[1] === relPath);
+  if (idx === -1) return { lines: [...lines, newLine], action: "inserted" };
+  const next = [...lines];
+  next[idx] = newLine;
+  return { lines: next, action: "updated" };
+}
+
+/**
+ * Remove a summary bullet by rel-path.
+ *
+ * Pure — returns a new array, does not mutate the input.
+ *
+ * @returns `{ lines, found: boolean }`; `lines` is the input when not found.
+ */
+export function deleteBullet(lines, relPath) {
+  const idx = lines.findIndex((l) => SUMMARY_RE.exec(l)?.[1] === relPath);
+  if (idx === -1) return { lines, found: false };
+  const next = [...lines];
+  next.splice(idx, 1);
+  return { lines: next, found: true };
+}
+
+// ── Index file IO ─────────────────────────────────────────────────────────
+
+/**
+ * Read sections from an index file.
+ *
+ * The main index carries `## Concepts` + `## Summaries`; shard files carry
+ * only `## Summaries`.
+ *
+ * @param filePath - Absolute path of the index file.
+ * @param requireConcepts - True for the main index (must contain Concepts).
+ */
+function parseIndexFile(filePath, requireConcepts) {
+  if (!existsSync(filePath)) {
+    return requireConcepts
+      ? { concepts: [], summaries: [] }
+      : { summaries: [] };
   }
 
-  const text = readFileSync(INDEX_PATH, "utf8");
-  const concepts = getBulletsFromSection(text, "Concepts");
+  const text = readFileSync(filePath, "utf8");
   const summaries = getBulletsFromSection(text, "Summaries");
-
-  if (concepts === null)
-    throw new Error("## Concepts section not found in Wiki/index.md");
   if (summaries === null)
-    throw new Error("## Summaries section not found in Wiki/index.md");
+    throw new Error(`## Summaries section not found in ${filePath}`);
+  if (!requireConcepts) return { summaries };
 
+  const concepts = getBulletsFromSection(text, "Concepts");
+  if (concepts === null)
+    throw new Error(`## Concepts section not found in ${filePath}`);
   return { concepts, summaries };
+}
+
+/** Read the main index (Concepts + Summaries). */
+function parseIndex() {
+  return parseIndexFile(INDEX_PATH, true);
+}
+
+/** Read the summary bullets of a shard (empty when the shard file does not exist yet). */
+function readShardSummaries(year) {
+  return parseIndexFile(shardIndexPath(year), false).summaries;
 }
 
 function conceptSortKey(line) {
@@ -64,16 +203,25 @@ function summarySortKey(line) {
   return (SUMMARY_RE.exec(line)?.[1] ?? line).toLowerCase();
 }
 
-function writeIndex(concepts, summaries) {
+/**
+ * Render the main index content: title + Archive (per-year shard links) + Concepts + Summaries.
+ * Pure — no IO.
+ */
+export function renderIndexContent(concepts, summaries, archiveYears) {
   const sortedConcepts = [...concepts].sort((a, b) =>
     conceptSortKey(a).localeCompare(conceptSortKey(b)),
   );
   const sortedSummaries = [...summaries].sort((a, b) =>
     summarySortKey(a).localeCompare(summarySortKey(b)),
   );
+  const archiveLines = archiveYears.map((y) => `- [[Wiki/index-${y}|${y}]]`);
 
-  const content = [
+  return [
     "# Knowledge Base Index",
+    "",
+    "## Archive",
+    "",
+    ...archiveLines,
     "",
     "## Concepts",
     "",
@@ -84,9 +232,36 @@ function writeIndex(concepts, summaries) {
     ...sortedSummaries,
     "",
   ].join("\n");
+}
 
+/** Render a per-year DailyNotes shard: title + Summaries. Pure — no IO. */
+export function renderShardContent(year, summaries) {
+  const sorted = [...summaries].sort((a, b) =>
+    summarySortKey(a).localeCompare(summarySortKey(b)),
+  );
+  return [
+    `# Daily Notes Index ${year}`,
+    "",
+    "## Summaries",
+    "",
+    ...sorted,
+    "",
+  ].join("\n");
+}
+
+/** Write the main index (render + IO). */
+function writeIndex(concepts, summaries) {
+  const content = renderIndexContent(concepts, summaries, listShardYears());
   mkdirSync(path.dirname(INDEX_PATH), { recursive: true });
   writeFileSync(INDEX_PATH, content, "utf8");
+}
+
+/** Write a per-year DailyNotes shard (render + IO). */
+function writeShard(year, summaries) {
+  const filePath = shardIndexPath(year);
+  const content = renderShardContent(year, summaries);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, "utf8");
 }
 
 // ── Dispatch (guarded: runs only when this file is the entry point) ─────
@@ -101,8 +276,17 @@ if (
     case "sort": {
       const { concepts, summaries } = parseIndex();
       writeIndex(concepts, summaries);
+      let summaryTotal = summaries.length;
+      for (const year of listShardYears()) {
+        const { summaries: shardSummaries } = parseIndexFile(
+          shardIndexPath(year),
+          false,
+        );
+        writeShard(year, shardSummaries);
+        summaryTotal += shardSummaries.length;
+      }
       console.log(
-        `Sorted ${concepts.length} concepts and ${summaries.length} summaries.`,
+        `Sorted ${concepts.length} concepts and ${summaryTotal} summaries.`,
       );
       break;
     }
@@ -114,7 +298,16 @@ if (
     }
 
     case "read-summaries": {
+      const all = args.includes("--all");
       const { summaries } = parseIndex();
+      if (all) {
+        for (const year of listShardYears()) {
+          summaries.push(...readShardSummaries(year));
+        }
+        summaries.sort((a, b) =>
+          summarySortKey(a).localeCompare(summarySortKey(b)),
+        );
+      }
       if (summaries.length > 0)
         process.stdout.write(`${summaries.join("\n")}\n`);
       break;
@@ -198,19 +391,37 @@ if (
           ? description
           : `${description.slice(0, description.lastIndexOf(" ", 197))} …`;
 
-      const { concepts, summaries } = parseIndex();
-      const idx = summaries.findIndex(
-        (l) => SUMMARY_RE.exec(l)?.[1] === relPath,
-      );
       const newLine = `- [[Wiki/Summaries/${relPath}]] — ${truncated}`;
-      if (idx === -1) {
-        summaries.push(newLine);
-        writeIndex(concepts, summaries);
-        console.log(`Inserted summary '${relPath}'.`);
+      const target = resolveIndexTarget(relPath);
+
+      if (target.type === "shard") {
+        // ── Per-year shard (DailyNotes) ──
+        const shardPath = shardIndexPath(target.year);
+        const isNewShard = !existsSync(shardPath);
+        const { lines, action } = upsertBullet(
+          readShardSummaries(target.year),
+          relPath,
+          newLine,
+        );
+        writeShard(target.year, lines);
+        if (isNewShard) {
+          // First entry for this year: the main index's Archive section is
+          // rendered from listShardYears() at the last writeIndex, so a
+          // brand-new shard is not yet linked. Refresh the main index.
+          const { concepts, summaries } = parseIndex();
+          writeIndex(concepts, summaries);
+        }
+        console.log(
+          `${action === "inserted" ? "Inserted" : "Updated"} summary '${relPath}' in Wiki/index-${target.year}.md.`,
+        );
       } else {
-        summaries[idx] = newLine;
-        writeIndex(concepts, summaries);
-        console.log(`Updated summary '${relPath}'.`);
+        // ── Main index ──
+        const { concepts, summaries } = parseIndex();
+        const { lines, action } = upsertBullet(summaries, relPath, newLine);
+        writeIndex(concepts, lines);
+        console.log(
+          `${action === "inserted" ? "Inserted" : "Updated"} summary '${relPath}'.`,
+        );
       }
       break;
     }
@@ -218,29 +429,57 @@ if (
     case "delete-summary": {
       const [relPath] = args;
       if (!relPath) {
-        console.error('Usage: delete-summary "<rel-path>"');
+        console.error("Usage: delete-summary <rel-path>");
         process.exit(1);
       }
-      const { concepts, summaries } = parseIndex();
-      const idx = summaries.findIndex(
-        (l) => SUMMARY_RE.exec(l)?.[1] === relPath,
-      );
-      if (idx === -1) {
-        console.error(`Error: summary '${relPath}' not found.`);
-        process.exit(1);
+      const target = resolveIndexTarget(relPath);
+
+      if (target.type === "shard") {
+        const { lines, found } = deleteBullet(
+          readShardSummaries(target.year),
+          relPath,
+        );
+        if (!found) {
+          console.error(`Error: summary '${relPath}' not found.`);
+          process.exit(1);
+        }
+        writeShard(target.year, lines);
+        console.log(
+          `Deleted summary '${relPath}' from Wiki/index-${target.year}.md.`,
+        );
+      } else {
+        const { concepts, summaries } = parseIndex();
+        const { lines, found } = deleteBullet(summaries, relPath);
+        if (!found) {
+          console.error(`Error: summary '${relPath}' not found.`);
+          process.exit(1);
+        }
+        writeIndex(concepts, lines);
+        console.log(`Deleted summary '${relPath}'.`);
       }
-      summaries.splice(idx, 1);
-      writeIndex(concepts, summaries);
-      console.log(`Deleted summary '${relPath}'.`);
       break;
     }
 
     case "find-missing-summaries": {
       const summariesDir = path.join(KNOWLEDGE_DIR, "Wiki", "Summaries");
+      const indexed = new Set();
+
       const { summaries } = parseIndex();
-      const indexed = new Set(
-        summaries.map((l) => SUMMARY_RE.exec(l)?.[1]).filter(Boolean),
-      );
+      for (const l of summaries) {
+        const relPath = SUMMARY_RE.exec(l)?.[1];
+        if (relPath) indexed.add(relPath);
+      }
+      for (const year of listShardYears()) {
+        const { summaries: shardSummaries } = parseIndexFile(
+          shardIndexPath(year),
+          false,
+        );
+        for (const l of shardSummaries) {
+          const relPath = SUMMARY_RE.exec(l)?.[1];
+          if (relPath) indexed.add(relPath);
+        }
+      }
+
       const missing = [];
       if (existsSync(summariesDir)) {
         for (const file of readdirSync(summariesDir, { recursive: true })) {
@@ -274,9 +513,12 @@ if (
     }
 
     case "delete-dead-links": {
+      const deletedConcepts = [];
+      const deletedSummaries = [];
+
+      // ── Main index ──
       const { concepts, summaries } = parseIndex();
 
-      const deletedConcepts = [];
       const keptConcepts = concepts.filter((l) => {
         const slug = CONCEPT_RE.exec(l)?.[1];
         if (!slug) return true;
@@ -288,7 +530,6 @@ if (
         return false;
       });
 
-      const deletedSummaries = [];
       const keptSummaries = summaries.filter((l) => {
         const relPath = SUMMARY_RE.exec(l)?.[1];
         if (!relPath) return true;
@@ -306,10 +547,68 @@ if (
         writeIndex(keptConcepts, keptSummaries);
       }
 
+      // ── Per-year shards ──
+      for (const year of listShardYears()) {
+        const { summaries: shardSummaries } = parseIndexFile(
+          shardIndexPath(year),
+          false,
+        );
+        const keptShard = shardSummaries.filter((l) => {
+          const relPath = SUMMARY_RE.exec(l)?.[1];
+          if (!relPath) return true;
+          if (
+            existsSync(
+              path.join(KNOWLEDGE_DIR, "Wiki", "Summaries", `${relPath}.md`),
+            )
+          )
+            return true;
+          deletedSummaries.push(l);
+          return false;
+        });
+        if (keptShard.length !== shardSummaries.length) {
+          writeShard(year, keptShard);
+        }
+      }
+
       console.log(
         JSON.stringify({
           concepts: deletedConcepts.length,
           summaries: deletedSummaries.length,
+        }),
+      );
+      break;
+    }
+
+    case "split-daily-shards": {
+      // ── One-time migration: split DailyNotes entries out of the main index ──
+      const { concepts, summaries } = parseIndex();
+      const { shards, kept } = partitionShardLines(summaries);
+
+      if (shards.size === 0) {
+        console.log("no-op: no DailyNotes entries in the index.");
+        break;
+      }
+
+      // Backup the original main index before mutating anything. Include the
+      // time in the name so a same-day re-run cannot overwrite the
+      // pre-migration copy (index.md.bak-YYYYMMDDTHHMMSS).
+      const backupName = `index.md.bak-${new Date()
+        .toISOString()
+        .slice(0, 19)
+        .replaceAll("-", "")
+        .replaceAll(":", "")}`;
+      copyFileSync(INDEX_PATH, path.join(WIKI_DIR, backupName));
+
+      for (const [year, lines] of shards) {
+        writeShard(year, lines);
+      }
+      writeIndex(concepts, kept);
+
+      console.log(
+        JSON.stringify({
+          years: Object.fromEntries([...shards].map(([y, l]) => [y, l.length])),
+          kept: kept.length,
+          backup: backupName,
         }),
       );
       break;
@@ -331,6 +630,7 @@ if (
           "  find-missing-summaries",
           "  find-missing-concepts",
           "  delete-dead-links",
+          "  split-daily-shards",
         ].join("\n"),
       );
       process.exit(1);

--- a/skills/knowledge-wiki/lint/SKILL.md
+++ b/skills/knowledge-wiki/lint/SKILL.md
@@ -212,7 +212,7 @@ For each key in the output:
 
 ## Check 6 — Dead Index Links
 
-_Removes entries from `Wiki/index.md` that point to files that no longer exist on disk._
+_Removes entries from `Wiki/index*.md` (main index and per-year shards) that point to files that no longer exist on disk._
 
 ### 8. Remove dead index links
 
@@ -230,7 +230,9 @@ Otherwise record the counts for the final summary — no further action required
 
 ## Check 7 — Missing Summary Index Entries
 
-_Adds index entries for summary files on disk that have no Wikilink in `Wiki/index.md`._
+_Adds index entries for summary files on disk that have no Wikilink in `Wiki/index*.md` (main index and per-year shards)._
+
+DailyNotes summaries route into `Wiki/index-<year>.md` by their path year; other summaries go into `Wiki/index.md`.
 
 ### 9. Find summaries missing from the index
 
@@ -259,6 +261,8 @@ For each rel-path in the array:
 ## Check 8 — Missing Concept Index Entries
 
 _Adds index entries for concept files on disk that have no Wikilink in `Wiki/index.md`._
+
+Concept entries always live in the main index; year shards contain only DailyNotes summaries.
 
 ### 11. Find concepts missing from the index
 

--- a/skills/knowledge-wiki/lint/lib/graph.mjs
+++ b/skills/knowledge-wiki/lint/lib/graph.mjs
@@ -33,7 +33,8 @@ function findWikiFiles(dir, knowledgeDir, results = []) {
     } else if (
       entry.isFile() &&
       entry.name.endsWith(".md") &&
-      entry.name !== "index.md"
+      entry.name !== "index.md" &&
+      !/^index-\d{4}\.md$/.test(entry.name)
     ) {
       results.push(
         path.relative(knowledgeDir, fullPath).replaceAll(path.sep, "/"),

--- a/skills/knowledge-wiki/merge/lib/graph.mjs
+++ b/skills/knowledge-wiki/merge/lib/graph.mjs
@@ -33,7 +33,8 @@ function findWikiFiles(dir, knowledgeDir, results = []) {
     } else if (
       entry.isFile() &&
       entry.name.endsWith(".md") &&
-      entry.name !== "index.md"
+      entry.name !== "index.md" &&
+      !/^index-\d{4}\.md$/.test(entry.name)
     ) {
       results.push(
         path.relative(knowledgeDir, fullPath).replaceAll(path.sep, "/"),

--- a/skills/knowledge-wiki/state/SKILL.md
+++ b/skills/knowledge-wiki/state/SKILL.md
@@ -63,6 +63,9 @@ node ./wiki-index.mjs sort --base-path /path/to/knowledge-base
 # Read current entries
 node ./wiki-index.mjs read-concepts --base-path /path/to/knowledge-base
 node ./wiki-index.mjs read-summaries --base-path /path/to/knowledge-base
+# read-summaries lists only the main index by default; pass --all to also
+# include the per-year DailyNotes shards (Wiki/index-<year>.md):
+node ./wiki-index.mjs read-summaries --all --base-path /path/to/knowledge-base
 
 # Insert/update/delete entries
 node ./wiki-index.mjs upsert-concept <slug> "<display-name>" "<description>" --base-path /path/to/knowledge-base

--- a/skills/knowledge-wiki/state/wiki-index.mjs
+++ b/skills/knowledge-wiki/state/wiki-index.mjs
@@ -1,13 +1,20 @@
 /**
  * wiki-index.mjs
  *
- * Reads and writes Wiki/index.md.
+ * Reads and writes the knowledge base index files:
+ *   - Wiki/index.md             (main index: Archive + Concepts + Summaries)
+ *   - Wiki/index-<year>.md      (per-year DailyNotes shards)
+ *
+ * DailyNotes summaries are routed by path year into their shard:
+ *   Wiki/Summaries/Calendar/DailyNotes/<year>/... → Wiki/index-<year>.md
+ * Everything else (Notes/, Concepts, non-year DailyNotes entries) → Wiki/index.md
+ *
  * Skills should call this instead of reading the whole file and writing it back.
  *
  * Usage:
  *   node scripts/wiki/wiki-index.mjs sort
  *   node scripts/wiki/wiki-index.mjs read-concepts
- *   node scripts/wiki/wiki-index.mjs read-summaries
+ *   node scripts/wiki/wiki-index.mjs read-summaries [--all]
  *   node scripts/wiki/wiki-index.mjs upsert-concept <slug> "<display-name>" "<description>"
  *   node scripts/wiki/wiki-index.mjs delete-concept <slug>
  *   node scripts/wiki/wiki-index.mjs upsert-summary "<rel-path>" "<description>"
@@ -15,11 +22,13 @@
  *   node scripts/wiki/wiki-index.mjs find-missing-summaries
  *   node scripts/wiki/wiki-index.mjs find-missing-concepts
  *   node scripts/wiki/wiki-index.mjs delete-dead-links
+ *   node scripts/wiki/wiki-index.mjs split-daily-shards
  *
  * --base-path can be added at any position to override the KNOWLEDGE_DIR.
  */
 
 import {
+  copyFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -29,7 +38,12 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { INDEX_PATH, KNOWLEDGE_DIR, SUMMARIES_DIR } from "./lib/paths.mjs";
+import {
+  INDEX_PATH,
+  KNOWLEDGE_DIR,
+  SUMMARIES_DIR,
+  WIKI_DIR,
+} from "./lib/paths.mjs";
 import { getBulletsFromSection } from "./lib/sections.mjs";
 
 process.stdout.on("error", (err) => {
@@ -39,21 +53,146 @@ process.stdout.on("error", (err) => {
 const CONCEPT_RE = /^- \[\[Wiki\/Concepts\/([^|]+)\|([^\]]+)\]\] — (.+)$/;
 const SUMMARY_RE = /^- \[\[Wiki\/Summaries\/((?:[^\]]|\](?!\]))+)\]\] — (.+)$/;
 
-function parseIndex() {
-  if (!existsSync(INDEX_PATH)) {
-    return { concepts: [], summaries: [] };
+/** DailyNotes summary rel-paths that belong in a per-year shard. */
+const DAILY_SHARD_RE = /^Calendar\/DailyNotes\/(\d{4})\//;
+
+// ── Pure: shard routing & bullet editing ──────────────────────────────────
+
+/**
+ * Route a summary rel-path to its index target.
+ *
+ * Pure — value in / value out. Testable with table tests.
+ *
+ * @param relPath - Summary rel-path (e.g. `Calendar/DailyNotes/2026/2026-07-06`
+ *                  or `Notes/redis`).
+ * @returns `{ type: "shard", year }` for DailyNotes paths with a 4-digit year
+ *          subdirectory; `{ type: "main" }` for everything else (Notes/,
+ *          Concepts, or DailyNotes entries without a year subdirectory).
+ */
+export function resolveIndexTarget(relPath) {
+  const m = DAILY_SHARD_RE.exec(relPath);
+  return m ? { type: "shard", year: m[1] } : { type: "main" };
+}
+
+/**
+ * Absolute path of a per-year shard index file.
+ *
+ * `wikiDir` defaults to the module-resolved Wiki/ directory; callers (and
+ * tests) can pass an explicit wiki directory to avoid import-time
+ * environment coupling.
+ */
+export function shardIndexPath(year, wikiDir = WIKI_DIR) {
+  return path.join(wikiDir, `index-${year}.md`);
+}
+
+/**
+ * Years of all existing shard files (`Wiki/index-<year>.md`), sorted ascending.
+ * Used to render the Archive section and to iterate shards for lint/sort.
+ */
+export function listShardYears(wikiDir = WIKI_DIR) {
+  if (!existsSync(wikiDir)) return [];
+  const years = [];
+  for (const entry of readdirSync(wikiDir, { withFileTypes: true })) {
+    const m = /^index-(\d{4})\.md$/.exec(entry.name);
+    if (entry.isFile() && m) years.push(m[1]);
+  }
+  return years.sort((a, b) => a - b);
+}
+
+/**
+ * Partition summary bullets into per-year shard buckets and main-index kept lines.
+ *
+ * Pure — value in / value out, no IO. Testable with table tests.
+ *
+ * @param summaryLines - Summary bullets from the main index's `## Summaries` section.
+ * @returns `{ shards: Map<year, bullet[]>, kept: bullet[] }`.
+ */
+export function partitionShardLines(summaryLines) {
+  const shards = new Map();
+  const kept = [];
+  for (const line of summaryLines) {
+    const m = DAILY_SHARD_RE.exec(SUMMARY_RE.exec(line)?.[1] ?? "");
+    if (m) {
+      if (!shards.has(m[1])) shards.set(m[1], []);
+      shards.get(m[1]).push(line);
+    } else {
+      kept.push(line);
+    }
+  }
+  return { shards, kept };
+}
+
+/**
+ * Insert or update a summary bullet in a list of summary lines.
+ *
+ * Pure — returns a new array, does not mutate the input.
+ *
+ * @param lines - Existing summary bullets.
+ * @param relPath - Summary rel-path to match.
+ * @param newLine - Bullet to insert or replace with.
+ * @returns `{ lines, action: "inserted" | "updated" }`.
+ */
+export function upsertBullet(lines, relPath, newLine) {
+  const idx = lines.findIndex((l) => SUMMARY_RE.exec(l)?.[1] === relPath);
+  if (idx === -1) return { lines: [...lines, newLine], action: "inserted" };
+  const next = [...lines];
+  next[idx] = newLine;
+  return { lines: next, action: "updated" };
+}
+
+/**
+ * Remove a summary bullet by rel-path.
+ *
+ * Pure — returns a new array, does not mutate the input.
+ *
+ * @returns `{ lines, found: boolean }`; `lines` is the input when not found.
+ */
+export function deleteBullet(lines, relPath) {
+  const idx = lines.findIndex((l) => SUMMARY_RE.exec(l)?.[1] === relPath);
+  if (idx === -1) return { lines, found: false };
+  const next = [...lines];
+  next.splice(idx, 1);
+  return { lines: next, found: true };
+}
+
+// ── Index file IO ─────────────────────────────────────────────────────────
+
+/**
+ * Read sections from an index file.
+ *
+ * The main index carries `## Concepts` + `## Summaries`; shard files carry
+ * only `## Summaries`.
+ *
+ * @param filePath - Absolute path of the index file.
+ * @param requireConcepts - True for the main index (must contain Concepts).
+ */
+function parseIndexFile(filePath, requireConcepts) {
+  if (!existsSync(filePath)) {
+    return requireConcepts
+      ? { concepts: [], summaries: [] }
+      : { summaries: [] };
   }
 
-  const text = readFileSync(INDEX_PATH, "utf8");
-  const concepts = getBulletsFromSection(text, "Concepts");
+  const text = readFileSync(filePath, "utf8");
   const summaries = getBulletsFromSection(text, "Summaries");
-
-  if (concepts === null)
-    throw new Error("## Concepts section not found in Wiki/index.md");
   if (summaries === null)
-    throw new Error("## Summaries section not found in Wiki/index.md");
+    throw new Error(`## Summaries section not found in ${filePath}`);
+  if (!requireConcepts) return { summaries };
 
+  const concepts = getBulletsFromSection(text, "Concepts");
+  if (concepts === null)
+    throw new Error(`## Concepts section not found in ${filePath}`);
   return { concepts, summaries };
+}
+
+/** Read the main index (Concepts + Summaries). */
+function parseIndex() {
+  return parseIndexFile(INDEX_PATH, true);
+}
+
+/** Read the summary bullets of a shard (empty when the shard file does not exist yet). */
+function readShardSummaries(year) {
+  return parseIndexFile(shardIndexPath(year), false).summaries;
 }
 
 function conceptSortKey(line) {
@@ -64,16 +203,25 @@ function summarySortKey(line) {
   return (SUMMARY_RE.exec(line)?.[1] ?? line).toLowerCase();
 }
 
-function writeIndex(concepts, summaries) {
+/**
+ * Render the main index content: title + Archive (per-year shard links) + Concepts + Summaries.
+ * Pure — no IO.
+ */
+export function renderIndexContent(concepts, summaries, archiveYears) {
   const sortedConcepts = [...concepts].sort((a, b) =>
     conceptSortKey(a).localeCompare(conceptSortKey(b)),
   );
   const sortedSummaries = [...summaries].sort((a, b) =>
     summarySortKey(a).localeCompare(summarySortKey(b)),
   );
+  const archiveLines = archiveYears.map((y) => `- [[Wiki/index-${y}|${y}]]`);
 
-  const content = [
+  return [
     "# Knowledge Base Index",
+    "",
+    "## Archive",
+    "",
+    ...archiveLines,
     "",
     "## Concepts",
     "",
@@ -84,9 +232,36 @@ function writeIndex(concepts, summaries) {
     ...sortedSummaries,
     "",
   ].join("\n");
+}
 
+/** Render a per-year DailyNotes shard: title + Summaries. Pure — no IO. */
+export function renderShardContent(year, summaries) {
+  const sorted = [...summaries].sort((a, b) =>
+    summarySortKey(a).localeCompare(summarySortKey(b)),
+  );
+  return [
+    `# Daily Notes Index ${year}`,
+    "",
+    "## Summaries",
+    "",
+    ...sorted,
+    "",
+  ].join("\n");
+}
+
+/** Write the main index (render + IO). */
+function writeIndex(concepts, summaries) {
+  const content = renderIndexContent(concepts, summaries, listShardYears());
   mkdirSync(path.dirname(INDEX_PATH), { recursive: true });
   writeFileSync(INDEX_PATH, content, "utf8");
+}
+
+/** Write a per-year DailyNotes shard (render + IO). */
+function writeShard(year, summaries) {
+  const filePath = shardIndexPath(year);
+  const content = renderShardContent(year, summaries);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, "utf8");
 }
 
 // ── Dispatch (guarded: runs only when this file is the entry point) ─────
@@ -101,8 +276,17 @@ if (
     case "sort": {
       const { concepts, summaries } = parseIndex();
       writeIndex(concepts, summaries);
+      let summaryTotal = summaries.length;
+      for (const year of listShardYears()) {
+        const { summaries: shardSummaries } = parseIndexFile(
+          shardIndexPath(year),
+          false,
+        );
+        writeShard(year, shardSummaries);
+        summaryTotal += shardSummaries.length;
+      }
       console.log(
-        `Sorted ${concepts.length} concepts and ${summaries.length} summaries.`,
+        `Sorted ${concepts.length} concepts and ${summaryTotal} summaries.`,
       );
       break;
     }
@@ -114,7 +298,16 @@ if (
     }
 
     case "read-summaries": {
+      const all = args.includes("--all");
       const { summaries } = parseIndex();
+      if (all) {
+        for (const year of listShardYears()) {
+          summaries.push(...readShardSummaries(year));
+        }
+        summaries.sort((a, b) =>
+          summarySortKey(a).localeCompare(summarySortKey(b)),
+        );
+      }
       if (summaries.length > 0)
         process.stdout.write(`${summaries.join("\n")}\n`);
       break;
@@ -198,19 +391,37 @@ if (
           ? description
           : `${description.slice(0, description.lastIndexOf(" ", 197))} …`;
 
-      const { concepts, summaries } = parseIndex();
-      const idx = summaries.findIndex(
-        (l) => SUMMARY_RE.exec(l)?.[1] === relPath,
-      );
       const newLine = `- [[Wiki/Summaries/${relPath}]] — ${truncated}`;
-      if (idx === -1) {
-        summaries.push(newLine);
-        writeIndex(concepts, summaries);
-        console.log(`Inserted summary '${relPath}'.`);
+      const target = resolveIndexTarget(relPath);
+
+      if (target.type === "shard") {
+        // ── Per-year shard (DailyNotes) ──
+        const shardPath = shardIndexPath(target.year);
+        const isNewShard = !existsSync(shardPath);
+        const { lines, action } = upsertBullet(
+          readShardSummaries(target.year),
+          relPath,
+          newLine,
+        );
+        writeShard(target.year, lines);
+        if (isNewShard) {
+          // First entry for this year: the main index's Archive section is
+          // rendered from listShardYears() at the last writeIndex, so a
+          // brand-new shard is not yet linked. Refresh the main index.
+          const { concepts, summaries } = parseIndex();
+          writeIndex(concepts, summaries);
+        }
+        console.log(
+          `${action === "inserted" ? "Inserted" : "Updated"} summary '${relPath}' in Wiki/index-${target.year}.md.`,
+        );
       } else {
-        summaries[idx] = newLine;
-        writeIndex(concepts, summaries);
-        console.log(`Updated summary '${relPath}'.`);
+        // ── Main index ──
+        const { concepts, summaries } = parseIndex();
+        const { lines, action } = upsertBullet(summaries, relPath, newLine);
+        writeIndex(concepts, lines);
+        console.log(
+          `${action === "inserted" ? "Inserted" : "Updated"} summary '${relPath}'.`,
+        );
       }
       break;
     }
@@ -218,29 +429,57 @@ if (
     case "delete-summary": {
       const [relPath] = args;
       if (!relPath) {
-        console.error('Usage: delete-summary "<rel-path>"');
+        console.error("Usage: delete-summary <rel-path>");
         process.exit(1);
       }
-      const { concepts, summaries } = parseIndex();
-      const idx = summaries.findIndex(
-        (l) => SUMMARY_RE.exec(l)?.[1] === relPath,
-      );
-      if (idx === -1) {
-        console.error(`Error: summary '${relPath}' not found.`);
-        process.exit(1);
+      const target = resolveIndexTarget(relPath);
+
+      if (target.type === "shard") {
+        const { lines, found } = deleteBullet(
+          readShardSummaries(target.year),
+          relPath,
+        );
+        if (!found) {
+          console.error(`Error: summary '${relPath}' not found.`);
+          process.exit(1);
+        }
+        writeShard(target.year, lines);
+        console.log(
+          `Deleted summary '${relPath}' from Wiki/index-${target.year}.md.`,
+        );
+      } else {
+        const { concepts, summaries } = parseIndex();
+        const { lines, found } = deleteBullet(summaries, relPath);
+        if (!found) {
+          console.error(`Error: summary '${relPath}' not found.`);
+          process.exit(1);
+        }
+        writeIndex(concepts, lines);
+        console.log(`Deleted summary '${relPath}'.`);
       }
-      summaries.splice(idx, 1);
-      writeIndex(concepts, summaries);
-      console.log(`Deleted summary '${relPath}'.`);
       break;
     }
 
     case "find-missing-summaries": {
       const summariesDir = path.join(KNOWLEDGE_DIR, "Wiki", "Summaries");
+      const indexed = new Set();
+
       const { summaries } = parseIndex();
-      const indexed = new Set(
-        summaries.map((l) => SUMMARY_RE.exec(l)?.[1]).filter(Boolean),
-      );
+      for (const l of summaries) {
+        const relPath = SUMMARY_RE.exec(l)?.[1];
+        if (relPath) indexed.add(relPath);
+      }
+      for (const year of listShardYears()) {
+        const { summaries: shardSummaries } = parseIndexFile(
+          shardIndexPath(year),
+          false,
+        );
+        for (const l of shardSummaries) {
+          const relPath = SUMMARY_RE.exec(l)?.[1];
+          if (relPath) indexed.add(relPath);
+        }
+      }
+
       const missing = [];
       if (existsSync(summariesDir)) {
         for (const file of readdirSync(summariesDir, { recursive: true })) {
@@ -274,9 +513,12 @@ if (
     }
 
     case "delete-dead-links": {
+      const deletedConcepts = [];
+      const deletedSummaries = [];
+
+      // ── Main index ──
       const { concepts, summaries } = parseIndex();
 
-      const deletedConcepts = [];
       const keptConcepts = concepts.filter((l) => {
         const slug = CONCEPT_RE.exec(l)?.[1];
         if (!slug) return true;
@@ -288,7 +530,6 @@ if (
         return false;
       });
 
-      const deletedSummaries = [];
       const keptSummaries = summaries.filter((l) => {
         const relPath = SUMMARY_RE.exec(l)?.[1];
         if (!relPath) return true;
@@ -306,10 +547,68 @@ if (
         writeIndex(keptConcepts, keptSummaries);
       }
 
+      // ── Per-year shards ──
+      for (const year of listShardYears()) {
+        const { summaries: shardSummaries } = parseIndexFile(
+          shardIndexPath(year),
+          false,
+        );
+        const keptShard = shardSummaries.filter((l) => {
+          const relPath = SUMMARY_RE.exec(l)?.[1];
+          if (!relPath) return true;
+          if (
+            existsSync(
+              path.join(KNOWLEDGE_DIR, "Wiki", "Summaries", `${relPath}.md`),
+            )
+          )
+            return true;
+          deletedSummaries.push(l);
+          return false;
+        });
+        if (keptShard.length !== shardSummaries.length) {
+          writeShard(year, keptShard);
+        }
+      }
+
       console.log(
         JSON.stringify({
           concepts: deletedConcepts.length,
           summaries: deletedSummaries.length,
+        }),
+      );
+      break;
+    }
+
+    case "split-daily-shards": {
+      // ── One-time migration: split DailyNotes entries out of the main index ──
+      const { concepts, summaries } = parseIndex();
+      const { shards, kept } = partitionShardLines(summaries);
+
+      if (shards.size === 0) {
+        console.log("no-op: no DailyNotes entries in the index.");
+        break;
+      }
+
+      // Backup the original main index before mutating anything. Include the
+      // time in the name so a same-day re-run cannot overwrite the
+      // pre-migration copy (index.md.bak-YYYYMMDDTHHMMSS).
+      const backupName = `index.md.bak-${new Date()
+        .toISOString()
+        .slice(0, 19)
+        .replaceAll("-", "")
+        .replaceAll(":", "")}`;
+      copyFileSync(INDEX_PATH, path.join(WIKI_DIR, backupName));
+
+      for (const [year, lines] of shards) {
+        writeShard(year, lines);
+      }
+      writeIndex(concepts, kept);
+
+      console.log(
+        JSON.stringify({
+          years: Object.fromEntries([...shards].map(([y, l]) => [y, l.length])),
+          kept: kept.length,
+          backup: backupName,
         }),
       );
       break;
@@ -331,6 +630,7 @@ if (
           "  find-missing-summaries",
           "  find-missing-concepts",
           "  delete-dead-links",
+          "  split-daily-shards",
         ].join("\n"),
       );
       process.exit(1);

--- a/skills/knowledge-wiki/state/wiki-index.test.ts
+++ b/skills/knowledge-wiki/state/wiki-index.test.ts
@@ -1,0 +1,506 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// wiki-index.mjs is a CLI shell whose import-time knowledge-dir resolution
+// (lib/paths.mjs) exits the process when no knowledge base root is available.
+// Inject a dummy --base-path into argv BEFORE importing so the module loads.
+const BASE_DIR = join(tmpdir(), "wiki-index-test-base");
+process.argv.push("--base-path", BASE_DIR);
+
+const {
+  resolveIndexTarget,
+  shardIndexPath,
+  listShardYears,
+  partitionShardLines,
+  upsertBullet,
+  deleteBullet,
+  renderIndexContent,
+  renderShardContent,
+} = await import("./wiki-index.mjs");
+
+const CLI = new URL("./wiki-index.mjs", import.meta.url).pathname;
+
+// ── helpers ─────────────────────────────────────────────
+
+let kb: string;
+
+beforeEach(() => {
+  kb = mkdtempSync(join(tmpdir(), "wiki-index-kb-"));
+});
+
+afterEach(() => {
+  rmSync(kb, { recursive: true, force: true });
+});
+
+/** Run the CLI against the temp knowledge base. */
+function runCli(...args: string[]) {
+  return execFileSync(process.execPath, [CLI, ...args, "--base-path", kb], {
+    encoding: "utf8",
+  });
+}
+
+function writeKb(relPath: string, content: string) {
+  const full = join(kb, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content, "utf8");
+}
+
+function readKb(relPath: string) {
+  return readFileSync(join(kb, relPath), "utf8");
+}
+
+/** Minimal main index fixture: Concepts + Summaries sections. */
+const MAIN_INDEX = `# Knowledge Base Index
+
+## Concepts
+
+- [[Wiki/Concepts/redis|Redis]] — In-memory data store
+
+## Summaries
+
+- [[Wiki/Summaries/Notes/redis.summary]] — Redis note
+`;
+
+// ── Pure: resolveIndexTarget ────────────────────────────
+
+describe("resolveIndexTarget", () => {
+  it.each([
+    // DailyNotes with a 4-digit year subdirectory → shard
+    [
+      "Calendar/DailyNotes/2026/2026-07-06.summary",
+      { type: "shard", year: "2026" },
+    ],
+    [
+      "Calendar/DailyNotes/2023/2023-01-01.summary",
+      { type: "shard", year: "2023" },
+    ],
+    // Notes / concepts → main
+    ["Notes/redis.summary", { type: "main" }],
+    ["Notes/foo/bar.summary", { type: "main" }],
+    // DailyNotes entry WITHOUT a year subdirectory → main (e.g. raindrop archive)
+    ["Calendar/DailyNotes/raindrop-bookmarks-2026.summary", { type: "main" }],
+    // Other calendars → main
+    ["Calendar/Other/2026/x.summary", { type: "main" }],
+  ])("%s → %j", (relPath, expected) => {
+    expect(resolveIndexTarget(relPath)).toEqual(expected);
+  });
+});
+
+describe("shardIndexPath", () => {
+  it("builds the shard path under the given wiki dir", () => {
+    const wiki = join(kb, "Wiki");
+    expect(shardIndexPath("2026", wiki)).toBe(join(wiki, "index-2026.md"));
+    // Default falls back to the module-resolved Wiki dir (no env coupling needed
+    // when an explicit dir is passed).
+    expect(shardIndexPath("2026")).toBe(
+      join(BASE_DIR, "Wiki", "index-2026.md"),
+    );
+  });
+});
+
+describe("listShardYears", () => {
+  it("returns existing shard years sorted ascending, ignoring other files", () => {
+    const wiki = join(kb, "Wiki");
+    mkdirSync(wiki, { recursive: true });
+    writeFileSync(join(wiki, "index-2026.md"), "# x\n");
+    writeFileSync(join(wiki, "index-2023.md"), "# x\n");
+    writeFileSync(join(wiki, "index.md"), "# x\n");
+    writeFileSync(join(wiki, "index-abc.md"), "# x\n");
+
+    expect(listShardYears(wiki)).toEqual(["2023", "2026"]);
+  });
+});
+
+// ── Pure: partitionShardLines ───────────────────────────
+
+describe("partitionShardLines", () => {
+  it("buckets DailyNotes by year and keeps everything else in order", () => {
+    const lines = [
+      "- [[Wiki/Summaries/Calendar/DailyNotes/2023/2023-01-01.summary]] — A",
+      "- [[Wiki/Summaries/Calendar/DailyNotes/2026/2026-07-06.summary]] — B",
+      "- [[Wiki/Summaries/Calendar/DailyNotes/raindrop-bookmarks-2026.summary]] — C",
+      "- [[Wiki/Summaries/Notes/redis.summary]] — D",
+    ];
+    const { shards, kept } = partitionShardLines(lines);
+
+    expect([...shards.keys()]).toEqual(["2023", "2026"]);
+    expect(shards.get("2023")).toEqual([lines[0]]);
+    expect(shards.get("2026")).toEqual([lines[1]]);
+    expect(kept).toEqual([lines[2], lines[3]]);
+  });
+
+  it("returns empty shards and all lines as kept for non-DailyNotes input", () => {
+    const lines = ["- [[Wiki/Summaries/Notes/redis.summary]] — D"];
+    const { shards, kept } = partitionShardLines(lines);
+    expect(shards.size).toBe(0);
+    expect(kept).toEqual(lines);
+  });
+
+  it("treats malformed non-bullet lines as kept", () => {
+    const lines = ["- [[Wiki/Summaries/Notes/a.summary]] — A", "not a bullet"];
+    const { shards, kept } = partitionShardLines(lines);
+    expect(shards.size).toBe(0);
+    expect(kept).toEqual(lines);
+  });
+});
+
+// ── Pure: upsertBullet / deleteBullet ───────────────────
+
+describe("upsertBullet", () => {
+  it("inserts when the rel-path is absent and updates when present", () => {
+    const lines = ["- [[Wiki/Summaries/Notes/a.summary]] — A"];
+
+    const inserted = upsertBullet(
+      lines,
+      "Notes/b.summary",
+      "- [[Wiki/Summaries/Notes/b.summary]] — B",
+    );
+    expect(inserted.action).toBe("inserted");
+    expect(inserted.lines).toHaveLength(2);
+    expect(inserted.lines[1]).toContain("Notes/b.summary");
+    // input is not mutated
+    expect(lines).toHaveLength(1);
+
+    const updated = upsertBullet(
+      inserted.lines,
+      "Notes/a.summary",
+      "- [[Wiki/Summaries/Notes/a.summary]] — A2",
+    );
+    expect(updated.action).toBe("updated");
+    expect(updated.lines).toHaveLength(2);
+    expect(updated.lines[0]).toContain("A2");
+  });
+});
+
+describe("deleteBullet", () => {
+  it("removes the matching bullet and reports not-found otherwise", () => {
+    const lines = ["- [[Wiki/Summaries/Notes/a.summary]] — A"];
+
+    const hit = deleteBullet(lines, "Notes/a.summary");
+    expect(hit.found).toBe(true);
+    expect(hit.lines).toEqual([]);
+
+    const miss = deleteBullet(lines, "Notes/nope.summary");
+    expect(miss.found).toBe(false);
+    expect(miss.lines).toBe(lines);
+  });
+});
+
+// ── Pure: renderIndexContent / renderShardContent ───────
+
+describe("renderIndexContent", () => {
+  it("renders title, Archive, Concepts and Summaries with sorting", () => {
+    const content = renderIndexContent(
+      ["- [[Wiki/Concepts/b|B]] — b", "- [[Wiki/Concepts/a|A]] — a"],
+      [
+        "- [[Wiki/Summaries/Notes/z.summary]] — z",
+        "- [[Wiki/Summaries/Notes/a.summary]] — a",
+      ],
+      ["2023", "2026"],
+    );
+
+    expect(content).toContain("# Knowledge Base Index");
+    expect(content).toContain("## Archive");
+    expect(content).toContain("- [[Wiki/index-2023|2023]]");
+    expect(content.indexOf("## Concepts")).toBeLessThan(
+      content.indexOf("## Summaries"),
+    );
+    expect(content.indexOf("Wiki/Concepts/a")).toBeLessThan(
+      content.indexOf("Wiki/Concepts/b"),
+    );
+    expect(content.indexOf("Notes/a.summary")).toBeLessThan(
+      content.indexOf("Notes/z.summary"),
+    );
+  });
+});
+
+describe("renderShardContent", () => {
+  it("renders the shard title and sorted Summaries section", () => {
+    const content = renderShardContent("2026", [
+      "- [[Wiki/Summaries/Calendar/DailyNotes/2026/2026-07-06.summary]] — B",
+      "- [[Wiki/Summaries/Calendar/DailyNotes/2026/2026-01-01.summary]] — A",
+    ]);
+
+    expect(content).toContain("# Daily Notes Index 2026");
+    expect(content.indexOf("2026-01-01")).toBeLessThan(
+      content.indexOf("2026-07-06"),
+    );
+  });
+});
+
+// ── upsert-summary routing ──────────────────────────────
+
+describe("upsert-summary", () => {
+  it("routes DailyNotes entries into the year shard, adding only an Archive link to the main index", () => {
+    writeKb(
+      "Wiki/Summaries/Calendar/DailyNotes/2026/2026-07-06.summary.md",
+      "body",
+    );
+    writeKb("Wiki/index.md", MAIN_INDEX);
+
+    runCli(
+      "upsert-summary",
+      "Calendar/DailyNotes/2026/2026-07-06.summary",
+      "A daily note",
+    );
+
+    const shard = readKb("Wiki/index-2026.md");
+    expect(shard).toContain("# Daily Notes Index 2026");
+    expect(shard).toContain(
+      "[[Wiki/Summaries/Calendar/DailyNotes/2026/2026-07-06.summary]] — A daily note",
+    );
+    // The summary entry itself stays out of the main index…
+    expect(readKb("Wiki/index.md")).not.toContain("2026-07-06");
+    // …but the first upsert for the year links the new shard from Archive.
+    expect(readKb("Wiki/index.md")).toContain("- [[Wiki/index-2026|2026]]");
+  });
+
+  it("adds an Archive link to the main index when the year shard is first created", () => {
+    writeKb(
+      "Wiki/Summaries/Calendar/DailyNotes/2027/2027-01-01.summary.md",
+      "body",
+    );
+    writeKb("Wiki/index.md", MAIN_INDEX);
+
+    runCli(
+      "upsert-summary",
+      "Calendar/DailyNotes/2027/2027-01-01.summary",
+      "New year",
+    );
+
+    const main = readKb("Wiki/index.md");
+    expect(main).toContain("## Archive");
+    expect(main).toContain("- [[Wiki/index-2027|2027]]");
+  });
+
+  it("keeps a single Archive link when upserting into an existing shard", () => {
+    writeKb(
+      "Wiki/Summaries/Calendar/DailyNotes/2026/2026-07-06.summary.md",
+      "body",
+    );
+    writeKb("Wiki/index.md", MAIN_INDEX);
+
+    runCli(
+      "upsert-summary",
+      "Calendar/DailyNotes/2026/2026-07-06.summary",
+      "V1",
+    );
+    runCli(
+      "upsert-summary",
+      "Calendar/DailyNotes/2026/2026-07-06.summary",
+      "V2",
+    );
+
+    // Second upsert targets an existing shard — the main index is not
+    // rewritten, so the Archive link stays exactly once.
+    expect(readKb("Wiki/index.md").match(/index-2026/g)).toHaveLength(1);
+  });
+
+  it("updates an existing shard entry instead of duplicating it", () => {
+    writeKb(
+      "Wiki/Summaries/Calendar/DailyNotes/2026/2026-07-06.summary.md",
+      "body",
+    );
+    writeKb("Wiki/index.md", MAIN_INDEX);
+
+    runCli(
+      "upsert-summary",
+      "Calendar/DailyNotes/2026/2026-07-06.summary",
+      "V1",
+    );
+    runCli(
+      "upsert-summary",
+      "Calendar/DailyNotes/2026/2026-07-06.summary",
+      "V2",
+    );
+
+    const shard = readKb("Wiki/index-2026.md");
+    expect(shard.match(/V2/g)).toHaveLength(1);
+    expect(shard).not.toContain("V1");
+  });
+
+  it("routes Notes entries into the main index", () => {
+    writeKb("Wiki/Summaries/Notes/redis.summary.md", "body");
+    writeKb("Wiki/index.md", MAIN_INDEX);
+
+    runCli("upsert-summary", "Notes/redis.summary", "Redis note updated");
+
+    expect(readKb("Wiki/index.md")).toContain(
+      "[[Wiki/Summaries/Notes/redis.summary]] — Redis note updated",
+    );
+    expect(readKb("Wiki/index.md")).not.toContain("Redis note\n");
+  });
+});
+
+// ── split-daily-shards migration ────────────────────────
+
+describe("split-daily-shards", () => {
+  const SUMMARIES = [
+    ["Wiki/Summaries/Calendar/DailyNotes/2023/2023-01-01.summary.md", "body"],
+    ["Wiki/Summaries/Calendar/DailyNotes/2026/2026-07-06.summary.md", "body"],
+    [
+      "Wiki/Summaries/Calendar/DailyNotes/raindrop-bookmarks-2026.summary.md",
+      "body",
+    ],
+    ["Wiki/Summaries/Notes/redis.summary.md", "body"],
+  ];
+
+  const MIXED_INDEX = `# Knowledge Base Index
+
+## Concepts
+
+- [[Wiki/Concepts/redis|Redis]] — In-memory data store
+
+## Summaries
+
+- [[Wiki/Summaries/Calendar/DailyNotes/2023/2023-01-01.summary]] — Day one
+- [[Wiki/Summaries/Calendar/DailyNotes/2026/2026-07-06.summary]] — Today
+- [[Wiki/Summaries/Calendar/DailyNotes/raindrop-bookmarks-2026.summary]] — Bookmarks
+- [[Wiki/Summaries/Notes/redis.summary]] — Redis note
+`;
+
+  function buildMigratedKb() {
+    for (const [rel, content] of SUMMARIES) writeKb(rel, content);
+    writeKb("Wiki/index.md", MIXED_INDEX);
+  }
+
+  it("splits DailyNotes into year shards, keeps Notes in the main index, and backs up", () => {
+    buildMigratedKb();
+
+    const out = JSON.parse(runCli("split-daily-shards"));
+    expect(out).toMatchObject({ years: { "2023": 1, "2026": 1 }, kept: 2 });
+
+    // Shards contain exactly their year's entries.
+    const shard2023 = readKb("Wiki/index-2023.md");
+    expect(shard2023).toContain("# Daily Notes Index 2023");
+    expect(shard2023).toContain("2023-01-01.summary");
+    expect(shard2023).not.toContain("2026-07-06");
+
+    const shard2026 = readKb("Wiki/index-2026.md");
+    expect(shard2026).toContain("# Daily Notes Index 2026");
+    expect(shard2026).toContain("2026-07-06.summary");
+
+    // Main index keeps Concepts + Notes + non-year DailyNotes + Archive links.
+    const main = readKb("Wiki/index.md");
+    expect(main).toContain(
+      "[[Wiki/Summaries/Notes/redis.summary]] — Redis note",
+    );
+    expect(main).toContain(
+      "[[Wiki/Summaries/Calendar/DailyNotes/raindrop-bookmarks-2026.summary]] — Bookmarks",
+    );
+    expect(main).toContain("- [[Wiki/index-2023|2023]]");
+    expect(main).toContain("- [[Wiki/index-2026|2026]]");
+    expect(main).not.toContain("2023-01-01");
+    expect(main).not.toContain("2026-07-06");
+
+    // Backup of the original index exists.
+    const wikiFiles = readdirSync(join(kb, "Wiki"));
+    expect(wikiFiles.some((f) => f.startsWith("index.md.bak-"))).toBe(true);
+  });
+
+  it("is idempotent: a second run reports no-op", () => {
+    buildMigratedKb();
+    runCli("split-daily-shards");
+
+    const second = runCli("split-daily-shards");
+    expect(second).toContain("no-op");
+  });
+});
+
+// ── Cross-shard maintenance commands ────────────────────
+
+describe("delete-dead-links", () => {
+  it("removes dead summary links from both the main index and year shards", () => {
+    writeKb("Wiki/Summaries/Notes/alive.summary.md", "body");
+    writeKb(
+      "Wiki/Summaries/Calendar/DailyNotes/2023/2023-01-01.summary.md",
+      "body",
+    );
+    writeKb(
+      "Wiki/index.md",
+      `# Knowledge Base Index
+
+## Concepts
+
+- [[Wiki/Concepts/redis|Redis]] — In-memory data store
+
+## Summaries
+
+- [[Wiki/Summaries/Notes/alive.summary]] — Alive
+- [[Wiki/Summaries/Notes/dead.summary]] — Dead in main
+`,
+    );
+    writeKb(
+      "Wiki/index-2023.md",
+      `# Daily Notes Index 2023
+
+## Summaries
+
+- [[Wiki/Summaries/Calendar/DailyNotes/2023/2023-01-01.summary]] — Alive in shard
+- [[Wiki/Summaries/Calendar/DailyNotes/2023/2023-01-02.summary]] — Dead in shard
+`,
+    );
+
+    const out = JSON.parse(runCli("delete-dead-links"));
+    expect(out).toEqual({ concepts: 1, summaries: 2 });
+
+    const main = readKb("Wiki/index.md");
+    expect(main).toContain("Alive");
+    expect(main).not.toContain("Dead in main");
+
+    const shard = readKb("Wiki/index-2023.md");
+    expect(shard).toContain("Alive in shard");
+    expect(shard).not.toContain("Dead in shard");
+  });
+});
+
+describe("sort", () => {
+  it("sorts the main index and each shard independently", () => {
+    writeKb("Wiki/Summaries/Notes/b.summary.md", "body");
+    writeKb("Wiki/Summaries/Notes/a.summary.md", "body");
+    writeKb(
+      "Wiki/index.md",
+      `# Knowledge Base Index
+
+## Concepts
+
+- [[Wiki/Concepts/redis|Redis]] — In-memory data store
+
+## Summaries
+
+- [[Wiki/Summaries/Notes/b.summary]] — B
+- [[Wiki/Summaries/Notes/a.summary]] — A
+`,
+    );
+    writeKb(
+      "Wiki/index-2026.md",
+      `# Daily Notes Index 2026
+
+## Summaries
+
+- [[Wiki/Summaries/Calendar/DailyNotes/2026/2026-07-06.summary]] — Today
+- [[Wiki/Summaries/Calendar/DailyNotes/2026/2026-01-01.summary]] — Earlier
+`,
+    );
+
+    runCli("sort");
+
+    const main = readKb("Wiki/index.md");
+    expect(main.indexOf("a.summary")).toBeLessThan(main.indexOf("b.summary"));
+
+    const shard = readKb("Wiki/index-2026.md");
+    expect(shard.indexOf("2026-01-01")).toBeLessThan(
+      shard.indexOf("2026-07-06"),
+    );
+  });
+});

--- a/skills/knowledge-wiki/summary/lib/graph.mjs
+++ b/skills/knowledge-wiki/summary/lib/graph.mjs
@@ -33,7 +33,8 @@ function findWikiFiles(dir, knowledgeDir, results = []) {
     } else if (
       entry.isFile() &&
       entry.name.endsWith(".md") &&
-      entry.name !== "index.md"
+      entry.name !== "index.md" &&
+      !/^index-\d{4}\.md$/.test(entry.name)
     ) {
       results.push(
         path.relative(knowledgeDir, fullPath).replaceAll(path.sep, "/"),


### PR DESCRIPTION
- Route DailyNotes summary entries into Wiki/index-<year>.md by path year; Notes/ and Concepts stay in the main Wiki/index.md, which gains an ## Archive section linking every year shard
- Extract a pure core (resolveIndexTarget, partitionShardLines, upsertBullet, deleteBullet, renderIndexContent, renderShardContent) and keep the CLI commands as a thin read → decide → write shell
- Add split-daily-shards migration command (backup + idempotent no-op)
- Add read-summaries --all to aggregate shards; sort / find-missing-summaries / delete-dead-links now iterate the main index and every shard
- Exclude index-*.md shards from knowledge-graph discovery (5 graph.mjs copies)

fix(tasks): inject wiki-index.mjs path into the daily subagent prompt

- knowledge-wiki-daily now passes the absolute wiki-index.mjs path and defines the <path-to-wiki-index.mjs> placeholder
- prompts/wiki-summarize.md: replace stale .pi/skills/knowledge-wiki-* paths with skills/knowledge-wiki/{summary,concept,state}/... and document that placeholders are injected by the task configuration

test(knowledge-wiki): cover shard routing, bullet editing, rendering, migration

- Add wiki-index.test.ts: table-driven resolveIndexTarget, partitionShardLines, upsertBullet/deleteBullet, renderers, plus CLI integration tests for shard routing, split-daily-shards idempotency, and cross-shard lint/sort
- Extend knowledge-wiki-daily.test.ts to assert the injected index script path