### PR TITLE
feat(visual-artifact): add Cmd/Ctrl +/- keyboard zoom shortcuts to mermaid viewport

### DIFF
--- a/extensions/visual-artifact/ui/src/renderer/adapters/media/SvgViewport.svelte
+++ b/extensions/visual-artifact/ui/src/renderer/adapters/media/SvgViewport.svelte
@@ -21,6 +21,7 @@ import {
   parseViewBoxFromMarkup,
   stepZoom,
   type ViewBox,
+  zoomDirectionForKey,
 } from "./svg-viewport.ts";
 
 let {
@@ -221,6 +222,38 @@ $effect(() => {
   });
   return () =>
     window.removeEventListener("wheel", handlePinchWheel, { capture: true });
+});
+
+// Cmd/Ctrl+`+` / Cmd/Ctrl+`-` zoom shortcuts — window-level so they work
+// without hovering the diagram. Ignored while typing in editable elements
+// and in source view; preventDefault stops the browser's own page zoom.
+$effect(() => {
+  if (showSource || !normalizedSvg) return;
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    const target = event.target;
+    if (
+      target instanceof HTMLElement &&
+      (target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.tagName === "SELECT" ||
+        target.isContentEditable)
+    ) {
+      return;
+    }
+    const direction = zoomDirectionForKey(event.key, {
+      meta: event.metaKey,
+      ctrl: event.ctrlKey,
+      shift: event.shiftKey,
+      alt: event.altKey,
+    });
+    if (direction === null) return;
+    event.preventDefault();
+    updateZoom(stepZoom(zoomLevel, direction));
+  };
+
+  window.addEventListener("keydown", handleKeyDown);
+  return () => window.removeEventListener("keydown", handleKeyDown);
 });
 
 // Escape to close + body scroll lock while expanded.

--- a/extensions/visual-artifact/ui/src/renderer/adapters/media/svg-viewport.test.ts
+++ b/extensions/visual-artifact/ui/src/renderer/adapters/media/svg-viewport.test.ts
@@ -10,6 +10,7 @@ import {
   parseViewBoxFromMarkup,
   stepZoom,
   ZOOM_STEP,
+  zoomDirectionForKey,
 } from "./svg-viewport.ts";
 
 describe("parseViewBoxFromMarkup", () => {
@@ -173,6 +174,52 @@ describe("exceedsDragThreshold", () => {
   it("supports a custom threshold, strictly greater than", () => {
     expect(exceedsDragThreshold(5, 0, 5)).toBe(false);
     expect(exceedsDragThreshold(5.1, 0, 5)).toBe(true);
+  });
+});
+
+describe("zoomDirectionForKey", () => {
+  const meta = { meta: true };
+
+  it("maps Cmd/Meta+plus to zoom in", () => {
+    expect(zoomDirectionForKey("+", meta)).toBe(1);
+  });
+
+  it("maps Cmd/Meta+equal (plus without shift) to zoom in", () => {
+    expect(zoomDirectionForKey("=", meta)).toBe(1);
+  });
+
+  it("maps Cmd/Meta+minus to zoom out", () => {
+    expect(zoomDirectionForKey("-", meta)).toBe(-1);
+  });
+
+  it("maps Cmd/Meta+Shift+minus (key '_') to zoom out", () => {
+    expect(zoomDirectionForKey("_", meta)).toBe(-1);
+  });
+
+  it("accepts Ctrl as the modifier on non-mac platforms", () => {
+    expect(zoomDirectionForKey("+", { ctrl: true })).toBe(1);
+    expect(zoomDirectionForKey("-", { ctrl: true })).toBe(-1);
+  });
+
+  it("accepts either Cmd or Ctrl when both are held", () => {
+    expect(zoomDirectionForKey("+", { meta: true, ctrl: true })).toBe(1);
+  });
+
+  it("returns null without a Cmd/Ctrl modifier", () => {
+    expect(zoomDirectionForKey("+", {})).toBeNull();
+    expect(zoomDirectionForKey("+", { shift: true })).toBeNull();
+  });
+
+  it("returns null for Alt-modified combos", () => {
+    expect(zoomDirectionForKey("+", { meta: true, alt: true })).toBeNull();
+    expect(zoomDirectionForKey("-", { ctrl: true, alt: true })).toBeNull();
+  });
+
+  it("returns null for unrelated keys", () => {
+    expect(zoomDirectionForKey("a", meta)).toBeNull();
+    expect(zoomDirectionForKey("1", meta)).toBeNull();
+    expect(zoomDirectionForKey(" ", meta)).toBeNull();
+    expect(zoomDirectionForKey("ArrowUp", meta)).toBeNull();
   });
 });
 

--- a/extensions/visual-artifact/ui/src/renderer/adapters/media/svg-viewport.ts
+++ b/extensions/visual-artifact/ui/src/renderer/adapters/media/svg-viewport.ts
@@ -125,6 +125,44 @@ export function stepZoom(zoom: number, direction: 1 | -1): number {
   return clampZoom(zoom + direction * ZOOM_STEP);
 }
 
+export interface ZoomShortcutModifiers {
+  meta?: boolean;
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+}
+
+/**
+ * Decide the zoom direction for a Cmd/Ctrl+`+` / Cmd/Ctrl+`-` keyboard
+ * shortcut. Pure: takes primitive key/modifier values (no DOM types), so
+ * the Svelte shell unpacks the KeyboardEvent and delegates here.
+ *
+ * Accepts `+` (Shift+= on US/CN layouts), `=` (same key without Shift) and
+ * numpad variants for zoom in; `-` and `_` (Shift+-) for zoom out. Either
+ * Cmd or Ctrl works (mirrors the wheel handler's ctrlKey || metaKey);
+ * Alt-modified combos are ignored.
+ *
+ * Returns 1 (zoom in), -1 (zoom out), or null when the combo is not a zoom
+ * shortcut.
+ */
+export function zoomDirectionForKey(
+  key: string,
+  modifiers: ZoomShortcutModifiers = {},
+): 1 | -1 | null {
+  if (!modifiers.meta && !modifiers.ctrl) return null;
+  if (modifiers.alt) return null;
+  switch (key) {
+    case "+":
+    case "=":
+      return 1;
+    case "-":
+    case "_":
+      return -1;
+    default:
+      return null;
+  }
+}
+
 /**
  * Distinguish a drag (pan) from a plain click (annotation select).
  * Strictly greater than the threshold counts as a drag.


### PR DESCRIPTION


- add pure zoomDirectionForKey key mapping to svg-viewport.ts core
- wire window-level keydown handler in SvgViewport.svelte with editable-focus and source-view guards
- add unit tests for zoom shortcut mapping