### PR TITLE
fix(plannotator-auto): harden HTML review path, drop redundant flag

### DIFF
--- a/extensions/plannotator-auto/README.md
+++ b/extensions/plannotator-auto/README.md
@@ -31,7 +31,7 @@ Optional extra targets can be added with `plannotatorAuto.extraReviewTargets` as
 - `/plannotator-review` opens an interactive plan/spec file picker and submits the selected file for Plannotator review.
 - `Ctrl+Shift+R` opens the same plan/spec file picker.
 - `Ctrl+Alt+L` annotates the latest Markdown or HTML file modified in the current session with `plannotator annotate <file> --json`.
-- Markdown plan/spec/issue submissions use Plannotator's plan-review hook mode so version history and plan diffs are available. HTML submissions use `plannotator annotate <file> --render-html --gate --json`.
+- Markdown plan/spec/issue submissions use Plannotator's plan-review hook mode so version history and plan diffs are available. HTML submissions use `plannotator annotate <file> --gate --json` (HTML renders raw by default since Plannotator v0.22+).
 
 ## Configuration
 
@@ -70,7 +70,7 @@ Notes:
 Plannotator Auto requires the `plannotator` CLI to be available on `PATH`.
 
 - `plannotator` with a PermissionRequest hook payload on stdin for Markdown plan/spec/issue review
-- `plannotator annotate <file> --render-html --gate --json`
+- `plannotator annotate <file> --gate --json`
 - `plannotator annotate <file> --json`
 
 ## Logging

--- a/extensions/plannotator-auto/cli.ts
+++ b/extensions/plannotator-auto/cli.ts
@@ -4,6 +4,8 @@ export type CliReviewDecision = {
   approved: boolean;
   feedback?: string;
   exit?: boolean;
+  /** User closed the review without a decision (dismissed, not denied). */
+  dismissed?: boolean;
 };
 
 export type CliReviewResult =
@@ -172,7 +174,7 @@ const parseCliReviewResult = (stdout: string): CliReviewDecision => {
       return { approved: true };
     }
     if (parsed.decision === "dismissed") {
-      return { approved: false, exit: true };
+      return { approved: false, exit: true, dismissed: true };
     }
     return { approved: false, feedback: parsed.feedback ?? "" };
   } catch {
@@ -211,7 +213,7 @@ const parseCliPlanReviewResult = (stdout: string): CliReviewDecision => {
       return { approved: true };
     }
     if (parsed.decision === "dismissed") {
-      return { approved: false, exit: true };
+      return { approved: false, exit: true, dismissed: true };
     }
     if (parsed.decision === "annotated") {
       return { approved: false, feedback: parsed.feedback ?? "" };
@@ -247,15 +249,11 @@ export const runPlannotatorAnnotateCli = async (
   filePath: string,
   options: {
     gate?: boolean;
-    renderHtml?: boolean;
     signal?: AbortSignal;
     timeoutMs: number;
   },
 ): Promise<CliReviewResult> => {
   const args = ["annotate", filePath];
-  if (options.renderHtml) {
-    args.push("--render-html");
-  }
   if (options.gate) {
     args.push("--gate");
   }

--- a/extensions/plannotator-auto/code-review.ts
+++ b/extensions/plannotator-auto/code-review.ts
@@ -7,7 +7,6 @@ import type {
 import { runPlannotatorAnnotateCli } from "./cli.ts";
 import { extractBashPathCandidates, resolveToolPaths } from "./helpers.ts";
 import {
-  isHtmlPath,
   isPathWithinCwd,
   isReviewDocumentPath,
   toRepoRelativePath,
@@ -180,14 +179,11 @@ const annotateLatestReviewDocument = async (
     return;
   }
 
-  const renderHtml = isHtmlPath(latestDocument.absolutePath);
-
   try {
     const response = await runPlannotatorAnnotateCli(
       ctx,
       latestDocument.absolutePath,
       {
-        renderHtml,
         signal: ctx.signal,
         timeoutMs: SYNC_ANNOTATE_TIMEOUT_MS,
       },

--- a/extensions/plannotator-auto/index.annotate.test.ts
+++ b/extensions/plannotator-auto/index.annotate.test.ts
@@ -132,7 +132,7 @@ describe("annotate latest document shortcut", () => {
     }
   });
 
-  it("annotates latest HTML document with render-html CLI flag", async () => {
+  it("annotates latest HTML document without render-html CLI flag", async () => {
     vi.resetModules();
     const spawnSync = mockSpawnSync({
       status: 0,
@@ -161,7 +161,7 @@ describe("annotate latest document shortcut", () => {
 
       expect(spawnSync).toHaveBeenCalledWith(
         "plannotator",
-        ["annotate", latestPath, "--render-html", "--json"],
+        ["annotate", latestPath, "--json"],
         expect.objectContaining({ cwd: repoRoot }),
       );
     } finally {

--- a/extensions/plannotator-auto/index.submit-review.test.ts
+++ b/extensions/plannotator-auto/index.submit-review.test.ts
@@ -666,4 +666,115 @@ parentFn()
       await removeTempRepo(repoRoot);
     }
   });
+
+  it("releases the gate without settling when the review is dismissed", async () => {
+    vi.resetModules();
+
+    mockSpawn({
+      status: 0,
+      stdout: JSON.stringify({ decision: "dismissed" }),
+      stderr: "",
+    });
+
+    const plannotatorAuto = await importPlannotatorAuto();
+    const { emit, runTool, api } = createFakePi();
+    plannotatorAuto(api as never);
+
+    const repoRoot = await createTempRepo("plannotator-auto-submit-dismiss-");
+    const planFileRelative = getPlanFileRelative(repoRoot);
+    await writeTestFile(repoRoot, planFileRelative, PLAN_DRAFT_CONTENT);
+    const ctx = createTestContext(repoRoot);
+
+    try {
+      await emit("session_start", {}, ctx);
+      await emitToolWrite(emit, ctx, planFileRelative);
+
+      const result = (await runTool(
+        "plannotator_auto_submit_review",
+        { path: planFileRelative },
+        ctx,
+      )) as { details?: { status?: string } };
+      expect(result.details?.status).toBe("dismissed");
+
+      // Gate released: no pending-review message on the next agent turn.
+      const gateResult = (await emit("before_agent_start", {}, ctx)) as {
+        message?: { content?: string };
+      };
+      expect(gateResult).toBeUndefined();
+
+      // Not settled: the next write to the same file re-queues the review.
+      await emitToolWrite(emit, ctx, planFileRelative);
+      const requeuedGate = (await emit("before_agent_start", {}, ctx)) as {
+        message?: { content?: string };
+      };
+      expect(requeuedGate?.message?.content ?? "").toContain(
+        "plannotator_auto_submit_review",
+      );
+    } finally {
+      await emit("session_shutdown", {}, ctx);
+      await removeTempRepo(repoRoot);
+    }
+  });
+
+  it("omits markdown-only guidance from the HTML plan gate message", async () => {
+    vi.resetModules();
+
+    const plannotatorAuto = await importPlannotatorAuto();
+    const { emit, api } = createFakePi();
+    plannotatorAuto(api as never);
+
+    const repoRoot = await createTempRepo("plannotator-auto-html-gate-");
+    const repoName = repoRoot.split("/").pop() ?? "repo";
+    const planFileRelative = `.pi/plans/${repoName}/plan/2026-04-16-workflow.html`;
+    await writeTestFile(
+      repoRoot,
+      planFileRelative,
+      "<!doctype html><html><body>Plan</body></html>",
+    );
+    const ctx = createTestContext(repoRoot);
+
+    try {
+      await emit("session_start", {}, ctx);
+      await emitToolWrite(emit, ctx, planFileRelative);
+
+      const gateResult = (await emit("before_agent_start", {}, ctx)) as {
+        message?: { content?: string };
+      };
+      const content = gateResult?.message?.content ?? "";
+      expect(content).toContain(planFileRelative);
+      expect(content).not.toContain("Keep the first # heading");
+      expect(content).not.toContain("mermaid fenced blocks");
+    } finally {
+      await emit("session_shutdown", {}, ctx);
+      await removeTempRepo(repoRoot);
+    }
+  });
+
+  it("keeps markdown-only guidance when all pending targets are markdown", async () => {
+    vi.resetModules();
+
+    const plannotatorAuto = await importPlannotatorAuto();
+    const { emit, api } = createFakePi();
+    plannotatorAuto(api as never);
+
+    const repoRoot = await createTempRepo("plannotator-auto-md-gate-");
+    const planFileRelative = getPlanFileRelative(repoRoot);
+    await writeTestFile(repoRoot, planFileRelative, PLAN_DRAFT_CONTENT);
+    const ctx = createTestContext(repoRoot);
+
+    try {
+      await emit("session_start", {}, ctx);
+      await emitToolWrite(emit, ctx, planFileRelative);
+
+      const gateResult = (await emit("before_agent_start", {}, ctx)) as {
+        message?: { content?: string };
+      };
+      const content = gateResult?.message?.content ?? "";
+      expect(content).toContain("Keep the first # heading");
+      expect(content).toContain("mermaid fenced blocks");
+    } finally {
+      await emit("session_shutdown", {}, ctx);
+      await removeTempRepo(repoRoot);
+    }
+  });
 });

--- a/extensions/plannotator-auto/plan-review.ts
+++ b/extensions/plannotator-auto/plan-review.ts
@@ -51,6 +51,7 @@ type PlanReviewSubmitToolParams = {
 type PlanReviewDecisionLike = {
   approved?: boolean;
   feedback?: string;
+  dismissed?: boolean;
 };
 
 const getPendingPlanReviewTargets = (
@@ -189,12 +190,17 @@ const formatPendingPlanReviewPrompt = (planFiles: string[]): string => {
     `Your next required action is calling ${PLAN_REVIEW_SUBMIT_TOOL} ` +
     "with one pending path.";
   const deniedAction = `If a review is denied, revise that same file and call ${PLAN_REVIEW_SUBMIT_TOOL} again.`;
+  // Markdown-only guidance: HTML plans have no `# heading` and do not use
+  // ```mermaid fenced blocks, so the guidance would actively mislead agents.
+  const markdownGuidance = planFiles.some((file) => isHtmlPath(file))
+    ? ""
+    : ` ${KEEP_PLAN_HEADING_GUIDANCE} ${MERMAID_RENDERING_GUIDANCE}`;
 
   return [
     "[PLANNOTATOR AUTO - PENDING REVIEW]",
     "Pending review targets:",
     targets,
-    `${nextAction} ${deniedAction} ${KEEP_PLAN_HEADING_GUIDANCE} ${MERMAID_RENDERING_GUIDANCE}`,
+    `${nextAction} ${deniedAction}${markdownGuidance}`,
   ].join("\n\n");
 };
 
@@ -428,15 +434,49 @@ const approvePendingPlanReview = (
 const denyPendingPlanReview = (
   pendingPlanReview: PendingPlanReview,
   feedback?: string,
-) => ({
-  content: [
-    {
-      type: "text" as const,
-      text: `YOUR REVIEW WAS NOT APPROVED. Revise ${pendingPlanReview.planFile} and call ${PLAN_REVIEW_SUBMIT_TOOL} again after addressing this feedback. ${KEEP_PLAN_HEADING_GUIDANCE}\n\n${feedback || "Review changes requested."}`,
-    },
-  ],
-  details: { status: "denied" },
-});
+) => {
+  const headingGuidance = isHtmlPath(pendingPlanReview.resolvedPlanPath)
+    ? ""
+    : ` ${KEEP_PLAN_HEADING_GUIDANCE}`;
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `YOUR REVIEW WAS NOT APPROVED. Revise ${pendingPlanReview.planFile} and call ${PLAN_REVIEW_SUBMIT_TOOL} again after addressing this feedback.${headingGuidance}\n\n${feedback || "Review changes requested."}`,
+      },
+    ],
+    details: { status: "denied" },
+  };
+};
+
+const dismissPendingPlanReview = (
+  state: SessionRuntimeState,
+  cwd: string,
+  pendingPlanReviews: Map<string, PendingPlanReview>,
+  pendingPlanReview: PendingPlanReview,
+) => {
+  // Dismissed = no decision, no revision demand. Release the gate but do NOT
+  // settle the path: the next write to the same file re-queues the review.
+  clearPendingPlanReviewTarget(
+    state,
+    cwd,
+    pendingPlanReviews,
+    pendingPlanReview.resolvedPlanPath,
+  );
+  markPendingPlanReviewEventsHandled(state, cwd, [
+    pendingPlanReview.resolvedPlanPath,
+  ]);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Review dismissed for ${pendingPlanReview.planFile} without a decision. The pending gate is released; the file will be queued for review again on its next write, or review it anytime with the plan/spec file picker.`,
+      },
+    ],
+    details: { status: "dismissed" },
+  };
+};
 
 const completePendingPlanReview = (
   ctx: ExtensionContext,
@@ -448,6 +488,15 @@ const completePendingPlanReview = (
   setReviewWidget(ctx);
   if (result.approved) {
     return approvePendingPlanReview(
+      state,
+      ctx.cwd,
+      pendingPlanReviews,
+      pendingPlanReview,
+    );
+  }
+
+  if (result.dismissed) {
+    return dismissPendingPlanReview(
       state,
       ctx.cwd,
       pendingPlanReviews,
@@ -635,7 +684,6 @@ export const registerPlanReviewSubmitTool = (
               pendingPlanReview.resolvedPlanPath,
               {
                 gate: true,
-                renderHtml,
                 signal,
                 timeoutMs: SYNC_PLANNOTATOR_TIMEOUT_MS,
               },

--- a/extensions/plannotator-auto/review-picker.ts
+++ b/extensions/plannotator-auto/review-picker.ts
@@ -311,7 +311,7 @@ const runPlanReview = async (
   try {
     if (renderHtml) {
       const response = await runPlannotatorAnnotateCli(ctx, filePath, {
-        renderHtml: true,
+        gate: true,
         signal: ctx.signal,
         timeoutMs: SYNC_REVIEW_TIMEOUT_MS,
       });

--- a/skills/plannotator-visual-explainer/SKILL.md
+++ b/skills/plannotator-visual-explainer/SKILL.md
@@ -24,14 +24,20 @@ Three paths depending on content type. Each has its own references and structure
 
 Always deliver via Plannotator's annotation UI. Do NOT use `open` or `xdg-open`.
 
+For any deliverable that uses Mermaid, render every diagram with Mermaid 11 in both the light
+and dark palettes before opening the annotation UI. Rendering is a hard gate: an exception,
+empty SVG, or error output such as `aria-roledescription="error"` or `Syntax error in text`
+means the explainer is not deliverable. Fix the diagram or theme configuration and rerun both
+palettes until every SVG passes.
+
 **Plans/proposals** (user should approve/deny):
 ```bash
-plannotator annotate <file> --render-html --gate
+plannotator annotate <file> --gate
 ```
 
 **Everything else** (informational):
 ```bash
-plannotator annotate <file> --render-html
+plannotator annotate <file>
 ```
 
 ---

--- a/skills/plannotator-visual-explainer/references/design-system.md
+++ b/skills/plannotator-visual-explainer/references/design-system.md
@@ -1,10 +1,16 @@
 # Design System Reference
 
-Plan documents use Plannotator's semantic theme tokens. This makes them theme-aware: standalone files render with bundled defaults; embedded in the Plannotator UI, they inherit whatever theme is active (30+ themes, light and dark variants).
+Plan documents use Plannotator's semantic theme tokens. This makes them theme-aware: standalone files render with bundled defaults; embedded in the Plannotator UI, they follow the active theme (30+ themes, light and dark variants) **when the document declares the host theme opt-in** in its `<head>`:
+
+```html
+<meta name="plannotator-theme" content="host">
+```
+
+Without the tag, the viewer renders the document untouched and the `:root` defaults below are all the document ever sees.
 
 ## Standalone defaults
 
-Include this `:root` block so the plan works when opened directly in a browser. These are the Plannotator light theme values — they get overridden when embedded.
+Include this `:root` block so the plan works when opened directly in a browser. These are the Plannotator light theme values — with the opt-in meta tag above, they get overridden by the active theme when embedded.
 
 ```css
 :root {
@@ -38,7 +44,7 @@ Include this `:root` block so the plan works when opened directly in a browser. 
 }
 ```
 
-`--font-display` is plan-specific — used for headings and titles to create visual contrast with the body. It's not part of the core Plannotator theme, so it won't be overridden when embedded (which is the desired behavior).
+`--font-display` is plan-specific — used for headings and titles to create visual contrast with the body. It's not part of the core Plannotator theme, so even with the opt-in it won't be overridden when embedded (which is the desired behavior).
 
 ## Token usage map
 

--- a/skills/plannotator-visual-explainer/references/theme-override.md
+++ b/skills/plannotator-visual-explainer/references/theme-override.md
@@ -2,9 +2,19 @@
 
 When visual-explainer's workflow says to pick a palette and font pairing, use these Plannotator tokens instead. Everything else — layout, structure, components, anti-slop rules — stays as visual-explainer prescribes.
 
+## Host theme opt-in (required)
+
+Plannotator's HTML viewer renders arbitrary documents untouched — it never injects bare theme tokens into a document unless the document asks for them. For the generated file to follow the active Plannotator theme when embedded in raw HTML annotation mode, it MUST declare the opt-in in its `<head>`:
+
+```html
+<meta name="plannotator-theme" content="host">
+```
+
+With this tag present, the viewer overrides the document's bare tokens (`--background`, `--muted`, …) with the host theme's values and mirrors the host's light/dark mode. Without it, the `:root` defaults below are all the document ever sees.
+
 ## CSS Custom Properties
 
-Replace visual-explainer's `--bg`, `--surface`, `--border`, `--text`, `--accent` variables with Plannotator's semantic tokens. Include these as `:root` defaults so the file works standalone. When embedded in the Plannotator UI via `--render-html`, these get overridden by the active theme.
+Replace visual-explainer's `--bg`, `--surface`, `--border`, `--text`, `--accent` variables with Plannotator's semantic tokens. Include these as `:root` defaults so the file works standalone. When embedded in Plannotator's raw HTML annotation mode (with the meta opt-in above), these get overridden by the active theme.
 
 ```css
 :root {
@@ -71,18 +81,47 @@ The `--font-display` (serif) is still used for headings to create visual contras
 
 ## Mermaid theming
 
-When visual-explainer instructs you to set `themeVariables` in Mermaid config, use Plannotator tokens:
+Mermaid processes `themeVariables` itself and derives additional colors from them. That color-processing boundary does not accept every color syntax that browsers accept in CSS. Use Mermaid-compatible literal hex colors here instead of copying the semantic CSS token declarations above.
+
+Do not pass OKLCH color functions, CSS custom-property references such as `var()`, or `color-mix()` values directly into `themeVariables`. This restriction applies only to Mermaid's color-processing boundary. Continue using Plannotator's OKLCH custom properties and other modern color functions for ordinary page CSS.
+
+Use the same light/dark state as the page, but keep both Mermaid palettes literal. With the host-theme opt-in, Plannotator synchronizes `color-scheme`; standalone documents fall back to the operating-system preference:
 
 ```javascript
+const colorScheme = getComputedStyle(document.documentElement).colorScheme;
+const isDark = colorScheme === 'dark'
+  || (colorScheme === 'normal'
+    && window.matchMedia('(prefers-color-scheme: dark)').matches);
+
+const mermaidThemeVariables = isDark
+  ? {
+      darkMode: true,
+      primaryColor: '#9a9dff',
+      primaryTextColor: '#070b14',
+      primaryBorderColor: '#343b45',
+      lineColor: '#9da5b2',
+      secondaryColor: '#1e242e',
+      secondaryTextColor: '#dadee5',
+      tertiaryColor: '#1e242e',
+      tertiaryTextColor: '#dadee5',
+      background: '#070b14',
+    }
+  : {
+      primaryColor: '#5537eb',
+      primaryTextColor: '#ffffff',
+      primaryBorderColor: '#d4d8de',
+      lineColor: '#414853',
+      secondaryColor: '#e1e5eb',
+      secondaryTextColor: '#414853',
+      tertiaryColor: '#e1e5eb',
+      tertiaryTextColor: '#414853',
+      background: '#f3f5f9',
+    };
+
 mermaid.initialize({
   theme: 'base',
   themeVariables: {
-    primaryColor: 'oklch(0.50 0.25 280)',         // --primary
-    primaryTextColor: 'oklch(1 0 0)',              // --primary-foreground
-    primaryBorderColor: 'oklch(0.88 0.01 260)',    // --border
-    lineColor: 'oklch(0.40 0.02 260)',             // --muted-foreground
-    secondaryColor: 'oklch(0.92 0.01 260)',        // --muted
-    tertiaryColor: 'oklch(0.92 0.01 260)',         // --muted
+    ...mermaidThemeVariables,
     fontFamily: "'Inter', system-ui, sans-serif",
     fontSize: '14px',
   }
@@ -91,7 +130,7 @@ mermaid.initialize({
 
 ## Dark mode
 
-Plannotator handles dark/light via theme classes, not `prefers-color-scheme`. The standalone defaults above are the light theme. When embedded via `--render-html`, the active theme's tokens override automatically — no media query needed in the generated HTML.
+Plannotator handles dark/light via theme classes, not `prefers-color-scheme`. The standalone defaults above are the light theme. When embedded in raw HTML annotation mode (with the `plannotator-theme` meta opt-in), the active theme's tokens override automatically — no media query needed in the generated HTML.
 
 For standalone viewing, you may optionally add a `prefers-color-scheme: dark` block with the Plannotator dark theme values:
 


### PR DESCRIPTION
- Add --gate to picker HTML reviews so the Approve button is available and the approved branch is reachable
- Omit markdown-only guidance (first-#-heading, mermaid fence rules) from pending gates and denials when HTML targets are involved
- Treat dismissed reviews as no-decision: release the pending gate without settling, so the next write to the same file re-queues the review
- Stop passing --render-html to the annotate CLI; raw HTML rendering is the default since plannotator v0.22 (flag dropped from CLI help in v0.25)
- Sync plannotator-visual-explainer skill with upstream opt-in host-theme contract (meta plannotator-theme) and Mermaid hex palette guidance; fix stale design-system override claims
- Add tests: dismissed gate release/re-queue, HTML gate guidance omission, markdown guidance retention