### PR TITLE
fix(plannotator-auto): parse lavish-axi TOON output for HTML review

### DIFF
--- a/extensions/plannotator-auto/cli.ts
+++ b/extensions/plannotator-auto/cli.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import { decodeToon, type ToonObject } from "./lavish-toon.ts";
 
 export type CliReviewDecision = {
   approved: boolean;
@@ -378,53 +379,94 @@ const runLavishCli = async (
 
 const parseLavishOpenOutput = (stdout: string): LavishDecision => {
   const trimmed = stdout.trim();
-  try {
-    const parsed = JSON.parse(trimmed) as { session?: { status?: string } };
-    if (parsed.session?.status === "user-ended") {
-      return { kind: "user-ended" };
-    }
-  } catch {
-    // Fall through — a non-JSON open output still means the open was
-    // attempted; treat it as opened so the poll can run.
+  const session = getToonSession(trimmed);
+  if (session?.status === "user-ended") {
+    return { kind: "user-ended" };
   }
+  // Unknown shape (human-readable open output) still means the open was
+  // attempted; treat it as opened so the poll can run.
   return { kind: "opened" };
+};
+
+type ToonSession = {
+  status?: string;
+  session_ended?: boolean;
+  ended_by?: string;
+};
+
+const getToonSession = (stdout: string): ToonSession | undefined => {
+  const parsed = decodeToon(stdout);
+  if (!parsed) {
+    return undefined;
+  }
+  const session = parsed.session;
+  if (
+    typeof session !== "object" ||
+    session === null ||
+    Array.isArray(session)
+  ) {
+    return undefined;
+  }
+  return session as ToonSession;
+};
+
+const getToonNextStep = (parsed: ToonObject | null): string | undefined => {
+  if (parsed && typeof parsed.next_step === "string") {
+    return parsed.next_step;
+  }
+  return undefined;
 };
 
 const parseLavishPollOutput = (stdout: string): LavishDecision => {
   const trimmed = stdout.trim();
-  try {
-    const parsed = JSON.parse(trimmed) as {
-      session?: {
-        status?: string;
-        session_ended?: boolean;
-        ended_by?: string;
-      };
-      prompts?: Array<{ text?: string; tag?: string }>;
-      next_step?: string;
-    };
-    const prompts = (parsed.prompts ?? [])
-      .map((prompt) => prompt.text ?? "")
-      .filter((text) => text.trim().length > 0);
-    const sessionStatus = parsed.session?.status;
-    if (sessionStatus === "ended") {
-      return {
-        kind: "ended",
-        endedBy: parsed.session?.ended_by,
-        nextStep: parsed.next_step,
-      };
+  const parsed = decodeToon(trimmed);
+  const session = getToonSession(trimmed);
+  const status = session?.status ?? "waiting";
+
+  const prompts: string[] = [];
+  if (parsed && Array.isArray(parsed.prompts)) {
+    for (const prompt of parsed.prompts) {
+      if (typeof prompt === "string") {
+        if (prompt.trim().length > 0) {
+          prompts.push(prompt);
+        }
+        continue;
+      }
+      if (
+        typeof prompt !== "object" ||
+        prompt === null ||
+        Array.isArray(prompt)
+      ) {
+        continue;
+      }
+      const record = prompt as ToonObject;
+      const text =
+        typeof record.text === "string"
+          ? record.text
+          : typeof record.prompt === "string"
+            ? record.prompt
+            : undefined;
+      if (text !== undefined && text.trim().length > 0) {
+        prompts.push(text);
+      }
     }
-    return {
-      kind: "feedback",
-      prompts,
-      sessionEnded: Boolean(parsed.session?.session_ended),
-      endedBy: parsed.session?.ended_by,
-      nextStep: parsed.next_step,
-    };
-  } catch {
-    // Non-JSON poll output (e.g. interrupted wait) — treat as empty feedback;
-    // queued feedback is never lost, so a later poll re-run still delivers it.
-    return { kind: "feedback", prompts: [], sessionEnded: false };
   }
+
+  if (status === "ended") {
+    return {
+      kind: "ended",
+      endedBy: session?.ended_by,
+      nextStep: getToonNextStep(parsed),
+    };
+  }
+
+  return {
+    kind: "feedback",
+    prompts,
+    sessionEnded: session?.session_ended === true,
+    endedBy: session?.ended_by,
+    nextStep: getToonNextStep(parsed),
+  };
 };
 
 export const runLavishOpenCli = async (

--- a/extensions/plannotator-auto/index.annotate.test.ts
+++ b/extensions/plannotator-auto/index.annotate.test.ts
@@ -53,6 +53,8 @@ import {
   createFakePi,
   createTempRepo,
   createTestContext,
+  lavishFeedbackStdout,
+  lavishOpenStdout,
   mockLavishSpawn,
   removeTempRepo,
   writeTestFile,
@@ -141,15 +143,15 @@ describe("annotate latest document shortcut", () => {
     const spawn = mockLavishSpawn(
       {
         status: 0,
-        stdout: JSON.stringify({ session: { status: "opened" } }),
+        stdout: lavishOpenStdout("/repo/visual.html"),
         stderr: "",
       },
       {
         status: 0,
-        stdout: JSON.stringify({
-          session: { status: "feedback", session_ended: false },
-          prompts: [{ text: "Please refine the HTML layout." }],
-        }),
+        stdout: lavishFeedbackStdout(
+          "/repo/visual.html",
+          "Please refine the HTML layout.",
+        ),
         stderr: "",
       },
     );

--- a/extensions/plannotator-auto/index.submit-review.test.ts
+++ b/extensions/plannotator-auto/index.submit-review.test.ts
@@ -6,6 +6,10 @@ import {
   createTempRepo,
   createTestContext,
   flushMicrotasks,
+  lavishEndedStdout as lavishEndedStdoutFixture,
+  lavishFeedbackStdout as lavishFeedbackStdoutFixture,
+  lavishOpenStdout as lavishOpenStdoutFixture,
+  lavishUserEndedStdout as lavishUserEndedStdoutFixture,
   mockHangingPlannotatorSpawn,
   mockLavishOpenThenHangingSpawn,
   mockLavishSpawn,
@@ -788,19 +792,15 @@ describe("lavish HTML artifact review", () => {
     return `.pi/html/${repoName}/2026-04-16-proto.html`;
   };
 
-  const lavishOpenStdout = JSON.stringify({
-    session: { status: "opened" },
-  });
-  const lavishUserEndedStdout = JSON.stringify({
-    session: { status: "user-ended" },
-  });
-  const lavishFeedbackStdout = JSON.stringify({
-    session: { status: "feedback", session_ended: false },
-    prompts: [{ text: "Please refine the layout." }],
-  });
-  const lavishEndedStdout = JSON.stringify({
-    session: { status: "ended" },
-  });
+  // `lavish-axi` emits TOON (not JSON); fixtures use the real shape.
+  const lavishOpenStdout = lavishOpenStdoutFixture("/repo/proto.html");
+  const lavishUserEndedStdout =
+    lavishUserEndedStdoutFixture("/repo/proto.html");
+  const lavishFeedbackStdout = lavishFeedbackStdoutFixture(
+    "/repo/proto.html",
+    "Please refine the layout.",
+  );
+  const lavishEndedStdout = lavishEndedStdoutFixture("/repo/proto.html");
 
   it("reviews HTML artifacts through Lavish open+poll and keeps the gate on feedback", async () => {
     vi.resetModules();

--- a/extensions/plannotator-auto/lavish-toon.test.ts
+++ b/extensions/plannotator-auto/lavish-toon.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import { decodeToon } from "./lavish-toon.ts";
+
+// Fixtures below are verbatim outputs captured from the real `lavish-axi`
+// CLI (v0.1.45) on macOS — the CLI serializes results with
+// `@toon-format/toon`, not JSON.
+
+// eslint-disable-next-line no-template-curly-in-string
+const realOpenOutput = [
+  "session:",
+  "  file: /private/tmp/lavish-test/test.html",
+  '  url: "http://127.0.0.1:4387/session/ddd909a7df9e37c2"',
+  "  status: opened",
+  'next_step: "Do not respond to the user just yet."',
+  "",
+].join("\n");
+
+const realUserEndedOpenOutput = [
+  "session:",
+  "  file: /private/tmp/lavish-test/test.html",
+  '  url: "http://127.0.0.1:4387/session/ddd909a7df9e37c2"',
+  "  status: user-ended",
+  'next_step: "The user explicitly ended this Lavish Editor session."',
+  "",
+].join("\n");
+
+const realFeedbackOutput = [
+  "session:",
+  "  file: /private/tmp/lavish-test/test.html",
+  "  status: feedback",
+  'dom_snapshot: ""',
+  "prompts[3]{uid,prompt,selector,tag,text}:",
+  '  "1",使用hello,html > body > h1,h1,test',
+  '  "",fix this,"",message,Freeform message',
+  '  "","","",feedback,The heading should be bigger.',
+  'next_step: "Apply the requested changes."',
+  "",
+].join("\n");
+
+const realEndedOutput = [
+  "session:",
+  "  file: /private/tmp/lavish-test/test.html",
+  "  status: ended",
+  "  ended_by: agent",
+  'next_step: "This Lavish Editor session has ended. Stop polling."',
+  "",
+].join("\n");
+
+describe("decodeToon (real lavish-axi output)", () => {
+  it("decodes a normal open result", () => {
+    const parsed = decodeToon(realOpenOutput);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.session).toEqual({
+      file: "/private/tmp/lavish-test/test.html",
+      url: "http://127.0.0.1:4387/session/ddd909a7df9e37c2",
+      status: "opened",
+    });
+    expect(typeof parsed?.next_step).toBe("string");
+  });
+
+  it("decodes a user-ended open result", () => {
+    const parsed = decodeToon(realUserEndedOpenOutput);
+    expect(parsed?.session).toMatchObject({ status: "user-ended" });
+  });
+
+  it("decodes a feedback poll result with tabular prompts", () => {
+    const parsed = decodeToon(realFeedbackOutput);
+    expect(parsed?.session).toMatchObject({ status: "feedback" });
+    expect(parsed?.dom_snapshot).toBe("");
+    expect(parsed?.prompts).toEqual([
+      {
+        uid: "1",
+        prompt: "使用hello",
+        selector: "html > body > h1",
+        tag: "h1",
+        text: "test",
+      },
+      {
+        uid: "",
+        prompt: "fix this",
+        selector: "",
+        tag: "message",
+        text: "Freeform message",
+      },
+      {
+        uid: "",
+        prompt: "",
+        selector: "",
+        tag: "feedback",
+        text: "The heading should be bigger.",
+      },
+    ]);
+    expect(typeof parsed?.next_step).toBe("string");
+  });
+
+  it("decodes an ended poll result", () => {
+    const parsed = decodeToon(realEndedOutput);
+    expect(parsed?.session).toMatchObject({
+      status: "ended",
+      ended_by: "agent",
+    });
+  });
+});
+
+describe("decodeToon edge cases", () => {
+  it("handles empty arrays", () => {
+    const parsed = decodeToon('prompts: []\nnext_step: "done"\n');
+    expect(parsed?.prompts).toEqual([]);
+    expect(parsed?.next_step).toBe("done");
+  });
+
+  it("handles quoted strings with commas inside tabular rows", () => {
+    const parsed = decodeToon(
+      [
+        "session:",
+        "  file: /repo/x.html",
+        "  status: feedback",
+        "prompts[2]{text,tag}:",
+        '  "Please refine the layout, and add a header.",message',
+        '  "Second one, with trailing comma.",feedback',
+        "",
+      ].join("\n"),
+    );
+    expect(parsed?.prompts).toEqual([
+      { text: "Please refine the layout, and add a header.", tag: "message" },
+      { text: "Second one, with trailing comma.", tag: "feedback" },
+    ]);
+  });
+
+  it("handles list-item arrays", () => {
+    const parsed = decodeToon(
+      [
+        "items[2]:",
+        '  - text: "first"',
+        '    tag: "a"',
+        '  - text: "second"',
+        "",
+      ].join("\n"),
+    );
+    expect(parsed?.items).toEqual([
+      { text: "first", tag: "a" },
+      { text: "second" },
+    ]);
+  });
+
+  it("returns null for empty input and does not crash on plain text", () => {
+    expect(decodeToon("")).toBeNull();
+    expect(decodeToon("   \n\n  ")).toBeNull();
+    // A bare error message is not a session/prompts document, but the
+    // decoder must not throw; callers fall back when `session` is missing.
+    const bare = decodeToon("error: lavish-axi session not active");
+    expect(bare).not.toBeNull();
+    expect(bare?.session).toBeUndefined();
+    expect(bare?.prompts).toBeUndefined();
+  });
+
+  it("handles booleans, numbers and null scalars", () => {
+    const parsed = decodeToon(
+      [
+        "session:",
+        "  status: feedback",
+        "  session_ended: true",
+        "  ended_by: user",
+        "count: 3",
+        "nothing: null",
+        "",
+      ].join("\n"),
+    );
+    expect(parsed?.session).toEqual({
+      status: "feedback",
+      session_ended: true,
+      ended_by: "user",
+    });
+    expect(parsed?.count).toBe(3);
+    expect(parsed?.nothing).toBeNull();
+  });
+});

--- a/extensions/plannotator-auto/lavish-toon.ts
+++ b/extensions/plannotator-auto/lavish-toon.ts
@@ -1,0 +1,278 @@
+/**
+ * Minimal decoder for the TOON output emitted by the `lavish-axi` CLI.
+ *
+ * `lavish-axi open`/`poll` serialize their results with
+ * `@toon-format/toon`'s `encode` (via the axi-sdk-js `runAxiCli`), so the
+ * raw stdout is TOON — never JSON. This module decodes the subset of TOON
+ * those two commands produce:
+ *
+ * - nested objects (`key:` + indented child lines)
+ * - scalar key/value lines (`key: value`, values may be quoted strings with
+ *   `\n \t \r \\ \" \uXXXX` escapes, numbers, booleans, `null`)
+ * - empty arrays (`key: []`)
+ * - tabular arrays (`key[N]{f1,f2,...}:` + indented comma-separated rows,
+ *   values quoted only when they contain the delimiter)
+ * - list-item arrays (`key[N]:` + `- item` lines)
+ *
+ * Unknown/unparsable input returns `null` so callers keep their previous
+ * fallback behavior instead of crashing.
+ */
+
+export type ToonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ToonValue[]
+  | ToonObject;
+
+export type ToonObject = { [key: string]: ToonValue };
+
+const charAt = (text: string, index: number): string =>
+  index < text.length ? (text[index] ?? "") : "";
+
+const parseToonScalar = (raw: string): ToonValue => {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return "";
+  }
+  if (trimmed === "null") {
+    return null;
+  }
+  if (trimmed === "true") {
+    return true;
+  }
+  if (trimmed === "false") {
+    return false;
+  }
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+    return Number(trimmed);
+  }
+  if (trimmed.startsWith('"')) {
+    return unescapeToonString(trimmed);
+  }
+  return trimmed;
+};
+
+/** Unescape a TOON quoted string; `raw` includes the surrounding quotes. */
+const unescapeToonString = (raw: string): string => {
+  let out = "";
+  let i = 1; // skip the opening quote
+  while (i < raw.length) {
+    const ch = charAt(raw, i);
+    if (ch === '"') {
+      return out;
+    }
+    if (ch !== "\\") {
+      out += ch;
+      i += 1;
+      continue;
+    }
+    const next = charAt(raw, i + 1);
+    if (next === "n") {
+      out += "\n";
+      i += 2;
+    } else if (next === "t") {
+      out += "\t";
+      i += 2;
+    } else if (next === "r") {
+      out += "\r";
+      i += 2;
+    } else if (next === "\\") {
+      out += "\\";
+      i += 2;
+    } else if (next === '"') {
+      out += '"';
+      i += 2;
+    } else if (next === "u") {
+      const hex = raw.slice(i + 2, i + 6);
+      if (/^[0-9a-f]{4}$/i.test(hex)) {
+        out += String.fromCodePoint(Number.parseInt(hex, 16));
+        i += 6;
+      } else {
+        out += next;
+        i += 2;
+      }
+    } else {
+      out += next;
+      i += 2;
+    }
+  }
+  return out;
+};
+
+/** Splits a tabular row on delimiters that are outside quoted sections. */
+const splitToonRow = (text: string): string[] => {
+  const parts: string[] = [];
+  let current = "";
+  let inQuote = false;
+  let i = 0;
+  while (i < text.length) {
+    const ch = charAt(text, i);
+    if (inQuote) {
+      if (ch === "\\" && i + 1 < text.length) {
+        current += ch + charAt(text, i + 1);
+        i += 2;
+        continue;
+      }
+      if (ch === '"') {
+        inQuote = false;
+      }
+      current += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === '"') {
+      inQuote = true;
+      current += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === ",") {
+      parts.push(current.trim());
+      current = "";
+      i += 1;
+      continue;
+    }
+    current += ch;
+    i += 1;
+  }
+  parts.push(current.trim());
+  return parts;
+};
+
+type ToonLine = {
+  indent: number;
+  text: string;
+};
+
+const toonLines = (text: string): ToonLine[] =>
+  text
+    .split("\n")
+    .map((line) => {
+      const match = /^(\s*)(.*)$/.exec(line);
+      return { indent: match?.[1]?.length ?? 0, text: match?.[2] ?? "" };
+    })
+    .filter((line) => line.text.length > 0 && !line.text.startsWith("#"));
+
+const parseKeyValue = (text: string): { key: string; rest: string } | null => {
+  const match = /^([^:]+):(?:\s*(.*))?$/.exec(text);
+  if (!match || match[1] === undefined) {
+    return null;
+  }
+  return { key: match[1].trim(), rest: match[2] ?? "" };
+};
+
+const TABULAR_ARRAY_HEADER = /^(.+)\[(\d+)\]\{([^}]*)\}$/;
+const LIST_ARRAY_HEADER = /^(.+)\[(\d+)\]$/;
+
+/**
+ * Decode a TOON document (as printed by `lavish-axi`). Returns `null` when
+ * the input does not look like TOON (e.g. a bare error message).
+ */
+export const decodeToon = (text: string): ToonObject | null => {
+  const lines = toonLines(text);
+  if (lines.length === 0) {
+    return null;
+  }
+
+  let pos = 0;
+
+  const parseScalarOrEmptyArray = (raw: string): ToonValue => {
+    if (raw.trim() === "[]") {
+      return [];
+    }
+    return parseToonScalar(raw);
+  };
+
+  const parseArrayItems = (
+    minIndent: number,
+    fields: string[] | undefined,
+  ): ToonValue[] => {
+    const items: ToonValue[] = [];
+    while (pos < lines.length) {
+      const line = lines[pos];
+      if (!line || line.indent < minIndent) {
+        break;
+      }
+      if (fields) {
+        const values = splitToonRow(line.text);
+        const row: ToonObject = {};
+        fields.forEach((field, index) => {
+          const cell = values[index];
+          row[field] = cell !== undefined ? parseToonScalar(cell) : "";
+        });
+        items.push(row);
+        pos += 1;
+        continue;
+      }
+      if (!line.text.startsWith("-")) {
+        pos += 1;
+        continue;
+      }
+      const itemText = line.text.slice(1).trim();
+      const kv = parseKeyValue(itemText);
+      if (!kv) {
+        items.push(parseScalarOrEmptyArray(itemText));
+        pos += 1;
+        continue;
+      }
+      pos += 1;
+      if (kv.rest !== "") {
+        const item: ToonObject = {
+          [kv.key]: parseScalarOrEmptyArray(kv.rest),
+        };
+        Object.assign(item, parseObject(line.indent + 1));
+        items.push(item);
+        continue;
+      }
+      items.push({ [kv.key]: parseObject(line.indent + 1) });
+    }
+    return items;
+  };
+
+  const parseObject = (minIndent: number): ToonObject => {
+    const obj: ToonObject = {};
+    while (pos < lines.length) {
+      const line = lines[pos];
+      if (!line || line.indent < minIndent) {
+        break;
+      }
+      const kv = parseKeyValue(line.text);
+      if (!kv) {
+        pos += 1;
+        continue;
+      }
+      const { key, rest } = kv;
+      if (rest !== "") {
+        obj[key] = parseScalarOrEmptyArray(rest);
+        pos += 1;
+        continue;
+      }
+
+      const tabular = TABULAR_ARRAY_HEADER.exec(key);
+      if (tabular && tabular[1] !== undefined && tabular[3] !== undefined) {
+        const fields = tabular[3]
+          .split(",")
+          .map((field) => field.trim())
+          .filter(Boolean);
+        pos += 1;
+        obj[tabular[1].trim()] = parseArrayItems(line.indent + 1, fields);
+        continue;
+      }
+
+      const listMatch = LIST_ARRAY_HEADER.exec(key);
+      if (listMatch && listMatch[1] !== undefined) {
+        pos += 1;
+        obj[listMatch[1].trim()] = parseArrayItems(line.indent + 1, undefined);
+        continue;
+      }
+
+      pos += 1;
+      obj[key] = parseObject(line.indent + 1);
+    }
+    return obj;
+  };
+
+  return parseObject(0);
+};

--- a/extensions/plannotator-auto/test-helpers.ts
+++ b/extensions/plannotator-auto/test-helpers.ts
@@ -131,10 +131,7 @@ export function mockLavishOpenThenHangingSpawn(
     if (callCount === 1) {
       const child = createMockPlannotatorChild();
       queueMicrotask(() => {
-        child.stdout.emit(
-          "data",
-          JSON.stringify({ session: { status: "opened" } }),
-        );
+        child.stdout.emit("data", lavishOpenStdout("/repo/proto.html"));
         child.emit("close", 0);
       });
       return child;
@@ -487,3 +484,59 @@ export async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
 }
+
+// --- Lavish (HTML artifact review) TOON output fixtures ---
+//
+// `lavish-axi` serializes its results with `@toon-format/toon`, not JSON.
+// These helpers build the real TOON shapes so tests guard the actual CLI
+// contract instead of a JSON approximation.
+
+const joinToonLines = (lines: string[]): string => `${lines.join("\n")}\n`;
+
+export const lavishOpenStdout = (filePath: string): string =>
+  joinToonLines([
+    "session:",
+    `  file: ${filePath}`,
+    '  url: "http://127.0.0.1:4387/session/test-session"',
+    "  status: opened",
+    'next_step: "Now run `lavish-axi poll` to wait for feedback."',
+  ]);
+
+export const lavishUserEndedStdout = (filePath: string): string =>
+  joinToonLines([
+    "session:",
+    `  file: ${filePath}`,
+    '  url: "http://127.0.0.1:4387/session/test-session"',
+    "  status: user-ended",
+    'next_step: "The user ended the session; do not reopen it."',
+  ]);
+
+const encodeToonScalar = (value: string): string => {
+  if (value === "" || /[,{}[\]:"#\n\r]/.test(value)) {
+    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  return value;
+};
+
+export const lavishFeedbackStdout = (
+  filePath: string,
+  feedback: string,
+): string =>
+  joinToonLines([
+    "session:",
+    `  file: ${filePath}`,
+    "  status: feedback",
+    'dom_snapshot: ""',
+    "prompts[1]{uid,prompt,selector,tag,text}:",
+    `  "","",,feedback,${encodeToonScalar(feedback)}`,
+    'next_step: "Apply the requested changes and re-poll."',
+  ]);
+
+export const lavishEndedStdout = (filePath: string): string =>
+  joinToonLines([
+    "session:",
+    `  file: ${filePath}`,
+    "  status: ended",
+    "  ended_by: agent",
+    'next_step: "This Lavish Editor session has ended. Stop polling."',
+  ]);


### PR DESCRIPTION
lavish-axi serializes open/poll results with @toon-format/toon, not JSON, so the JSON.parse-based parsers always failed and fell back to empty feedback: user feedback never reached the agent and ended sessions never released the review gate.

- add minimal TOON decoder for the lavish-axi open/poll output shapes (nested objects, quoted strings with escapes, tabular and list-item arrays)
- wire parseLavishOpenOutput/parseLavishPollOutput through the decoder so feedback prompts, ended/user-ended status and next_step are extracted
- switch test fixtures from JSON mocks to real TOON output and add decoder unit tests against captured lavish-axi output