### PR TITLE
feat(visual-artifact): accordion expands all panels by default

### DIFF
--- a/extensions/visual-artifact/artifact-schema.ts
+++ b/extensions/visual-artifact/artifact-schema.ts
@@ -377,8 +377,13 @@ export const NODE_TYPE_CATALOG: NodeTypeEntry[] = [
   {
     type: "accordion",
     label: "Accordion",
-    description: "Collapsible groups of nested nodes.",
-    props: { items: "{ title: string; nodes: ArtifactNode[] }[]" },
+    description:
+      "Collapsible groups of nested nodes. All items are expanded by default; " +
+      "set defaultOpen: false on an item to start it collapsed.",
+    props: {
+      items:
+        "{ title: string; nodes: ArtifactNode[]; defaultOpen?: boolean }[]",
+    },
   },
   {
     type: "section",

--- a/extensions/visual-artifact/ui-html.test.ts
+++ b/extensions/visual-artifact/ui-html.test.ts
@@ -1,8 +1,25 @@
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { build } from "vite";
+import { beforeAll, describe, expect, it } from "vitest";
 import { createVisualArtifactHtml } from "./ui-html.ts";
+
+// The first test asserts properties of the real production bundle, so the
+// built ui-dist must exist. Build it on demand when missing (e.g. a fresh
+// checkout); prepack / visual-artifact:ui:build produce it in releases.
+const UI_DIST_DIR = new URL("./ui-dist", import.meta.url);
+
+beforeAll(async () => {
+  if (existsSync(new URL("index.html", UI_DIST_DIR))) {
+    return;
+  }
+  await build({
+    configFile: "extensions/visual-artifact/vite.config.mts",
+    logLevel: "warn",
+  });
+}, 120_000);
 
 describe("createVisualArtifactHtml", () => {
   it("produces self-contained html without runtime chunk URLs", async () => {

--- a/extensions/visual-artifact/ui/src/renderer/adapters/layout/accordion.svelte
+++ b/extensions/visual-artifact/ui/src/renderer/adapters/layout/accordion.svelte
@@ -13,15 +13,27 @@ let {
   _nodePath?: string;
 } = $props();
 
-function initialOpenIndex(): number | null {
-  const idx = items.findIndex((item) => item.defaultOpen === true);
-  return idx >= 0 ? idx : null;
+// 默认全部展开;单项设 defaultOpen: false 可默认折叠
+function initialOpenSet(): Set<number> {
+  const set = new Set<number>();
+  items.forEach((item, i) => {
+    if (item.defaultOpen !== false) {
+      set.add(i);
+    }
+  });
+  return set;
 }
 
-let openIndex = $state<number | null>(initialOpenIndex());
+let openSet = $state<Set<number>>(initialOpenSet());
 
 function toggle(i: number): void {
-  openIndex = openIndex === i ? null : i;
+  const next = new Set(openSet);
+  if (next.has(i)) {
+    next.delete(i);
+  } else {
+    next.add(i);
+  }
+  openSet = next;
 }
 </script>
 
@@ -31,13 +43,13 @@ function toggle(i: number): void {
       <div class="border-b border-border last:border-b-0">
         <button
           type="button"
-          class="flex justify-between items-center w-full px-4 py-3 text-left text-sm font-medium text-foreground bg-transparent border-none cursor-pointer hover:bg-muted/50 {openIndex === i ? 'bg-muted' : ''}"
+          class="flex justify-between items-center w-full px-4 py-3 text-left text-sm font-medium text-foreground bg-transparent border-none cursor-pointer hover:bg-muted/50 {openSet.has(i) ? 'bg-muted' : ''}"
           onclick={() => toggle(i)}
         >
           {item.title}
-          <span class="text-muted-foreground text-xs ml-2 shrink-0">{openIndex === i ? "▾" : "▸"}</span>
+          <span class="text-muted-foreground text-xs ml-2 shrink-0">{openSet.has(i) ? "▾" : "▸"}</span>
         </button>
-        {#if openIndex === i}
+        {#if openSet.has(i)}
           <div class="px-4 pb-4">
             <VisualArtifactRenderer nodes={item.nodes} basePath={`${_nodePath}.props.items.${i}.nodes`} />
           </div>


### PR DESCRIPTION
- accordion adapter: default to all panels open, switch to multi-open toggling, and support defaultOpen: false to start an item collapsed
- artifact-schema: document the accordion defaultOpen prop
- ui-html.test: build ui-dist on demand when missing so the real-bundle assertions pass on a fresh checkout