### PR TITLE
fix(plan-mode): align todo discipline and htmlDirs semantics with review findings

### DIFF
--- a/extensions/plan-mode/controller-decisions.ts
+++ b/extensions/plan-mode/controller-decisions.ts
@@ -1,5 +1,12 @@
-import { promptRequestsPlanMode } from "./state.ts";
-import type { InputSource, PlanMode, PlanPhase, PlanRun } from "./types.ts";
+import { normalizeTodoStatus, promptRequestsPlanMode } from "./state.ts";
+import type {
+  InputSource,
+  PlanMode,
+  PlanPhase,
+  PlanRun,
+  TodoItem,
+  TodoStatusInput,
+} from "./types.ts";
 
 export type AgentStartPreDecisionInput = {
   inputSourceForTurn: InputSource;
@@ -133,6 +140,41 @@ export type TodoDoneFlip = {
   id: number;
   /** Whether the item was ever in_progress during its run lifetime. */
   everInProgress: boolean;
+};
+
+export type TodoSetItemInput = {
+  text: string;
+  status?: TodoStatusInput;
+};
+
+/**
+ * Compute todo→done flips for a "set" replacement (③). Pure decision:
+ * `replaceTodos` assigns fresh ids 1..N in list order, so the new item at
+ * `index` corresponds to the old item with id `index + 1`. A done item
+ * whose predecessor was not already done is a flip; the predecessor's
+ * everInProgress carries over so the set path classifies the same
+ * transition exactly like the update path.
+ */
+export const doneFlipsFromSet = (
+  oldTodos: readonly TodoItem[],
+  newItems: readonly TodoSetItemInput[],
+): TodoDoneFlip[] => {
+  const oldById = new Map(oldTodos.map((todo) => [todo.id, todo]));
+  const flips: TodoDoneFlip[] = [];
+  newItems.forEach((item, index) => {
+    const status = normalizeTodoStatus(item.status ?? "todo");
+    if (status !== "done") {
+      return;
+    }
+    const previous = oldById.get(index + 1);
+    if (previous?.status !== "done") {
+      flips.push({
+        id: index + 1,
+        everInProgress: previous?.everInProgress ?? false,
+      });
+    }
+  });
+  return flips;
 };
 
 export type TodoDisciplineReason = "no-in-progress" | "batch-done";

--- a/extensions/plan-mode/controller.ts
+++ b/extensions/plan-mode/controller.ts
@@ -67,7 +67,7 @@ import {
   relativeToolPath,
   turnWasAborted,
 } from "./guards.ts";
-import { isHtmlArtifactPath, resolveHtmlArtifactDirs } from "./html-dirs.ts";
+import { isHtmlArtifactPathIn, resolveHtmlArtifactDirs } from "./html-dirs.ts";
 import {
   getSessionStateEntries,
   hasCompletedAllTodos,
@@ -157,11 +157,12 @@ export class PlanModeController {
   private turnDoneFlips: TodoDoneFlip[] = [];
   private todoReminderMarkers = new Set<string>();
   private todoReminderCounts: Record<string, number> = {};
-  private cwd = process.cwd();
+  // Session-scoped values, resolved in restore() (no IO at construction).
+  private htmlArtifactDirs: string[] = [];
   constructor(private readonly pi: ExtensionAPI) {}
 
   restore(ctx: ExtensionContext): void {
-    this.cwd = ctx.cwd;
+    this.htmlArtifactDirs = resolveHtmlArtifactDirs(ctx.cwd);
     this.config = loadPlanModeConfig(ctx.cwd);
     const entries = getSessionStateEntries(ctx);
     this.state.restore(latestSnapshot(entries), this.config.defaultMode);
@@ -298,7 +299,7 @@ export class PlanModeController {
   }
 
   private getHtmlArtifactGuidanceLines(): string[] {
-    const dirs = resolveHtmlArtifactDirs(this.cwd);
+    const dirs = this.htmlArtifactDirs;
     if (dirs.length === 0) {
       return [];
     }
@@ -535,7 +536,10 @@ export class PlanModeController {
               exists: fs.existsSync(absolutePath),
               isInsideCwd,
               isReviewArtifact: isReviewArtifactPath(ctx.cwd, rawPath),
-              isHtmlArtifact: isHtmlArtifactPath(ctx.cwd, absolutePath),
+              isHtmlArtifact: isHtmlArtifactPathIn(
+                this.htmlArtifactDirs,
+                absolutePath,
+              ),
               wasRead: this.state.hasReadFile(absolutePath),
               wasFreshlyWritten: this.state.wasFileFreshlyWritten(absolutePath),
             };

--- a/extensions/plan-mode/html-dirs.test.ts
+++ b/extensions/plan-mode/html-dirs.test.ts
@@ -5,69 +5,109 @@ afterEach(() => {
   vi.doUnmock("../shared/settings.js");
 });
 
+const mockHtmlDirsSetting = (htmlDirs: string[] | null | undefined) => {
+  vi.resetModules();
+  vi.doMock("../shared/settings.js", async (importOriginal) => {
+    const original =
+      await importOriginal<typeof import("../shared/settings.js")>();
+    return {
+      ...original,
+      loadSettings: () => ({
+        global: {},
+        project: {},
+        merged: {
+          ...(htmlDirs === undefined ? {} : { plannotatorAuto: { htmlDirs } }),
+        },
+      }),
+    };
+  });
+  return import("./html-dirs.js");
+};
+
 describe("resolveHtmlArtifactDirs", () => {
   it("falls back to the default .pi/html/<repo> dir when no config is set", async () => {
-    vi.resetModules();
-    const { resolveHtmlArtifactDirs } = await import("./html-dirs.js");
+    const { resolveHtmlArtifactDirs } = await mockHtmlDirsSetting(undefined);
     expect(resolveHtmlArtifactDirs("/repo")).toContain("/repo/.pi/html/repo");
   });
 
   it("uses configured plannotatorAuto.htmlDirs when present", async () => {
-    vi.resetModules();
-    vi.doMock("../shared/settings.js", async (importOriginal) => {
-      const original =
-        await importOriginal<typeof import("../shared/settings.js")>();
-      return {
-        ...original,
-        loadSettings: () => ({
-          global: {},
-          project: {},
-          merged: {
-            plannotatorAuto: { htmlDirs: [".pi/html/custom"] },
-          },
-        }),
-      };
-    });
-    const { resolveHtmlArtifactDirs } = await import("./html-dirs.js");
+    const { resolveHtmlArtifactDirs } = await mockHtmlDirsSetting([
+      ".pi/html/custom",
+    ]);
     expect(resolveHtmlArtifactDirs("/repo")).toContain("/repo/.pi/html/custom");
     expect(resolveHtmlArtifactDirs("/repo")).not.toContain(
       "/repo/.pi/html/repo",
     );
   });
+
+  it("disables HTML review when htmlDirs is null (matches plannotator-auto)", async () => {
+    const { resolveHtmlArtifactDirs } = await mockHtmlDirsSetting(null);
+    expect(resolveHtmlArtifactDirs("/repo")).toEqual([]);
+  });
+
+  it("disables HTML review when htmlDirs is an empty array", async () => {
+    const { resolveHtmlArtifactDirs } = await mockHtmlDirsSetting([]);
+    expect(resolveHtmlArtifactDirs("/repo")).toEqual([]);
+  });
+
+  it("disables HTML review when htmlDirs entries are all blank", async () => {
+    const { resolveHtmlArtifactDirs } = await mockHtmlDirsSetting(["  "]);
+    expect(resolveHtmlArtifactDirs("/repo")).toEqual([]);
+  });
 });
 
-describe("isHtmlArtifactPath", () => {
-  it("matches dated HTML files under the default html dir", async () => {
-    vi.resetModules();
-    const { isHtmlArtifactPath } = await import("./html-dirs.js");
+describe("isHtmlArtifactPathIn", () => {
+  it("matches dated HTML files under the given dirs", async () => {
+    const { isHtmlArtifactPathIn, resolveHtmlArtifactDirs } =
+      await mockHtmlDirsSetting(undefined);
     expect(
-      isHtmlArtifactPath("/repo", "/repo/.pi/html/repo/2026-08-05-proto.html"),
+      isHtmlArtifactPathIn(
+        resolveHtmlArtifactDirs("/repo"),
+        "/repo/.pi/html/repo/2026-08-05-proto.html",
+      ),
     ).toBe(true);
   });
 
   it("rejects non-dated filenames", async () => {
-    vi.resetModules();
-    const { isHtmlArtifactPath } = await import("./html-dirs.js");
-    expect(isHtmlArtifactPath("/repo", "/repo/.pi/html/repo/proto.html")).toBe(
-      false,
-    );
+    const { isHtmlArtifactPathIn, resolveHtmlArtifactDirs } =
+      await mockHtmlDirsSetting(undefined);
+    expect(
+      isHtmlArtifactPathIn(
+        resolveHtmlArtifactDirs("/repo"),
+        "/repo/.pi/html/repo/proto.html",
+      ),
+    ).toBe(false);
   });
 
   it("rejects non-HTML files", async () => {
-    vi.resetModules();
-    const { isHtmlArtifactPath } = await import("./html-dirs.js");
+    const { isHtmlArtifactPathIn, resolveHtmlArtifactDirs } =
+      await mockHtmlDirsSetting(undefined);
     expect(
-      isHtmlArtifactPath("/repo", "/repo/.pi/html/repo/2026-08-05-proto.md"),
+      isHtmlArtifactPathIn(
+        resolveHtmlArtifactDirs("/repo"),
+        "/repo/.pi/html/repo/2026-08-05-proto.md",
+      ),
     ).toBe(false);
   });
 
   it("rejects files outside the html dirs", async () => {
-    vi.resetModules();
-    const { isHtmlArtifactPath } = await import("./html-dirs.js");
+    const { isHtmlArtifactPathIn, resolveHtmlArtifactDirs } =
+      await mockHtmlDirsSetting(undefined);
     expect(
-      isHtmlArtifactPath(
-        "/repo",
+      isHtmlArtifactPathIn(
+        resolveHtmlArtifactDirs("/repo"),
         "/repo/.pi/plans/repo/plan/2026-08-05-x.html",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects everything when HTML review is disabled (empty dirs)", async () => {
+    const { isHtmlArtifactPathIn, resolveHtmlArtifactDirs } =
+      await mockHtmlDirsSetting(null);
+    expect(
+      isHtmlArtifactPathIn(
+        resolveHtmlArtifactDirs("/repo"),
+        "/repo/.pi/html/repo/2026-08-05-proto.html",
       ),
     ).toBe(false);
   });

--- a/extensions/plan-mode/html-dirs.ts
+++ b/extensions/plan-mode/html-dirs.ts
@@ -1,77 +1,53 @@
 import path from "node:path";
-import { DEFAULT_GIT_TIMEOUT_MS, getGitCommonDir } from "../shared/git.ts";
+import {
+  HTML_REVIEW_FILE_PATTERN,
+  resolveHtmlReviewDirs,
+} from "../shared/review-targets.ts";
 import { loadSettings } from "../shared/settings.ts";
 
 /**
  * Resolve the HTML artifact review directories for the session cwd.
  *
- * Source of truth is the `plannotatorAuto.htmlDirs` setting (same config the
- * plannotator-auto extension watches); when it is unset or empty the default
- * `.pi/html/<repo>/` is used (repo slug from the git common dir, falling back
- * to the cwd basename — equivalent to plannotator-auto's getDefaultHtmlDirs).
+ * Source of truth is the `plannotatorAuto.htmlDirs` setting, resolved by the
+ * shared `resolveHtmlReviewDirs` (the same single source plannotator-auto
+ * uses for its review queue): `null`/`[]` disables HTML review, unset falls
+ * back to the default `.pi/html/<repo>/` (repo slug from the git common
+ * dir, falling back to the cwd basename).
  *
  * Used both for the buildModePrompt guidance line and for the plan-phase
  * write guard, so the agent is told exactly the directories it may write to.
+ *
+ * Callers that run on the tool-call hot path (the write guard) should cache
+ * the result per session (the controller resolves it in restore()) instead
+ * of re-running the settings load / git spawn on every tool call.
  */
-
-const resolveRepoSlugFromGitCommonDir = (cwd: string): string | null => {
-  const commonDir = getGitCommonDir(cwd, DEFAULT_GIT_TIMEOUT_MS);
-  if (!commonDir) {
-    return null;
-  }
-  const candidate = path.basename(path.dirname(commonDir)).trim();
-  return candidate.length > 0 ? candidate : null;
-};
-
-const getDefaultHtmlDirs = (cwd: string): string[] =>
-  Array.from(
-    new Set(
-      [resolveRepoSlugFromGitCommonDir(cwd), path.basename(cwd).trim()]
-        .filter((candidate): candidate is string => Boolean(candidate))
-        .map((candidate) => path.join(".pi", "html", candidate)),
-    ),
-  );
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === "object" && !Array.isArray(value);
 
-const getConfiguredHtmlDirs = (cwd: string): string[] => {
+const getConfiguredHtmlDirs = (cwd: string): unknown => {
   const { merged } = loadSettings(cwd);
   const config = merged.plannotatorAuto;
   if (!isRecord(config)) {
-    return [];
+    return undefined;
   }
-  const htmlDirs = config.htmlDirs;
-  if (!Array.isArray(htmlDirs)) {
-    return [];
-  }
-  return htmlDirs.flatMap((entry) => {
-    if (typeof entry !== "string") {
-      return [];
-    }
-    const trimmed = entry.trim();
-    return trimmed.length > 0 ? [trimmed] : [];
-  });
+  return config.htmlDirs;
 };
 
 /**
  * Absolute HTML artifact review directories for `cwd`.
  * Returns [] when htmlDirs is configured as null/[] (HTML review disabled).
  */
-export const resolveHtmlArtifactDirs = (cwd: string): string[] => {
-  const configured = getConfiguredHtmlDirs(cwd);
-  const dirs = configured.length > 0 ? configured : getDefaultHtmlDirs(cwd);
-  return Array.from(new Set(dirs.map((dir) => path.resolve(cwd, dir))));
-};
+export const resolveHtmlArtifactDirs = (cwd: string): string[] =>
+  resolveHtmlReviewDirs(cwd, getConfiguredHtmlDirs(cwd));
 
-/** True when `absolutePath` is a reviewable HTML artifact under htmlDirs. */
-export const isHtmlArtifactPath = (
-  cwd: string,
+/** True when `absolutePath` is a reviewable HTML artifact under `dirs`. */
+export const isHtmlArtifactPathIn = (
+  dirs: readonly string[],
   absolutePath: string,
 ): boolean => {
-  const dirs = resolveHtmlArtifactDirs(cwd);
   const fileName = path.basename(absolutePath);
-  if (!/^\d{4}-\d{2}-\d{2}-.+\.html$/.test(fileName)) {
+  if (!HTML_REVIEW_FILE_PATTERN.test(fileName)) {
     return false;
   }
   return dirs.some((dir) => path.dirname(absolutePath) === dir);

--- a/extensions/plan-mode/state.ts
+++ b/extensions/plan-mode/state.ts
@@ -102,6 +102,27 @@ export const phaseForMode = (mode: PlanMode): PlanPhase =>
 export const hasCompletedAllTodos = (todos: TodoItem[]): boolean =>
   todos.length > 0 && todos.every((todo) => todo.status === TODO_STATUS_DONE);
 
+/**
+ * Pure decision for the one-at-a-time discipline normalization (①): the
+ * index of the first todo item that should become in_progress, or -1 when
+ * nothing should be promoted (an item is already in_progress, any item is
+ * blocked, or no pending todo item exists). Mutation is applied by the
+ * caller (PlanModeState.normalizeTodoDiscipline).
+ */
+export const nextTodoToPromoteIndex = (todos: readonly TodoItem[]): number => {
+  const hasInProgress = todos.some(
+    (todo) => todo.status === TODO_STATUS_IN_PROGRESS,
+  );
+  if (hasInProgress) {
+    return -1;
+  }
+  const hasBlocked = todos.some((todo) => todo.status === TODO_STATUS_BLOCKED);
+  if (hasBlocked) {
+    return -1;
+  }
+  return todos.findIndex((todo) => todo.status === TODO_STATUS_TODO);
+};
+
 export const isPlanRunStatus = (value: unknown): value is PlanRunStatus =>
   isStringValue(PLAN_RUN_STATUS_VALUES, value);
 
@@ -680,7 +701,8 @@ export class PlanModeState {
     for (const item of items) {
       this.addTodo(item.text, item.status ?? TODO_STATUS_TODO, item.notes);
     }
-    this.refreshActiveRunStatus();
+    this.syncActiveRunStatus();
+    this.normalizeTodoDiscipline();
   }
 
   addTodo(
@@ -708,7 +730,8 @@ export class PlanModeState {
     this.todos.push(todo);
     this.activeRun.nextTodoId = this.nextTodoId;
     this.touchTodoUpdate();
-    this.refreshActiveRunStatus();
+    this.syncActiveRunStatus();
+    this.normalizeTodoDiscipline();
     return todo;
   }
 
@@ -735,7 +758,8 @@ export class PlanModeState {
       }
     }
     this.touchTodoUpdate();
-    this.refreshActiveRunStatus();
+    this.syncActiveRunStatus();
+    this.normalizeTodoDiscipline();
     return true;
   }
 
@@ -748,7 +772,8 @@ export class PlanModeState {
     if (before !== this.todos.length) {
       this.touchTodoUpdate();
     }
-    this.refreshActiveRunStatus();
+    this.syncActiveRunStatus();
+    this.normalizeTodoDiscipline();
     return before !== this.todos.length;
   }
 
@@ -782,37 +807,27 @@ export class PlanModeState {
    * Discipline normalization (①): whenever the run has unfinished items but no
    * in_progress and no blocked item, promote the first todo item to
    * in_progress so the widget always shows a current step. Also enforces the
-   * "at most one in_progress" invariant. Called from refreshActiveRunStatus,
-   * so every todo mutation path (set/add/update/remove) converges here.
+   * "at most one in_progress" invariant. The decision is the pure
+   * `nextTodoToPromoteIndex`; this method only applies it. Called explicitly
+   * after every todo mutation, alongside `syncActiveRunStatus`.
    */
-  private promoteFirstTodoIfNeeded(): void {
-    if (!this.activeRun) {
+  private normalizeTodoDiscipline(): void {
+    const index = nextTodoToPromoteIndex(this.todos);
+    if (index < 0) {
       return;
     }
-    const hasInProgress = this.todos.some(
-      (todo) => todo.status === TODO_STATUS_IN_PROGRESS,
-    );
-    if (hasInProgress) {
-      return;
-    }
-    const hasBlocked = this.todos.some(
-      (todo) => todo.status === TODO_STATUS_BLOCKED,
-    );
-    if (hasBlocked) {
-      return;
-    }
-    const firstTodo = this.todos.find(
-      (todo) => todo.status === TODO_STATUS_TODO,
-    );
-    if (!firstTodo) {
-      return;
-    }
-    firstTodo.status = TODO_STATUS_IN_PROGRESS;
-    firstTodo.everInProgress = true;
+    const candidate = this.todos[index];
+    candidate.status = TODO_STATUS_IN_PROGRESS;
+    candidate.everInProgress = true;
     this.touchTodoUpdate();
   }
 
-  refreshActiveRunStatus(): void {
+  /**
+   * Recompute the active run status from the todo list after a mutation.
+   * Pure status bookkeeping: does NOT touch todo items (the ① discipline
+   * normalization is applied separately by `normalizeTodoDiscipline`).
+   */
+  private syncActiveRunStatus(): void {
     if (!this.activeRun) {
       return;
     }
@@ -827,16 +842,12 @@ export class PlanModeState {
       }
       return;
     }
-    if (
-      !allTodosCompleted &&
-      this.activeRun.status === PLAN_RUN_STATUS_COMPLETED
-    ) {
+    if (this.activeRun.status === PLAN_RUN_STATUS_COMPLETED) {
       this.activeRun.status = this.activeRun.planPath
         ? PLAN_RUN_STATUS_EXECUTING
         : PLAN_RUN_STATUS_DRAFT;
       delete this.activeRun.completedAt;
     }
-    this.promoteFirstTodoIfNeeded();
   }
 
   snapshot(): PlanModeSnapshot {

--- a/extensions/plan-mode/todo-discipline.test.ts
+++ b/extensions/plan-mode/todo-discipline.test.ts
@@ -5,10 +5,11 @@ import {
   buildTodoDisciplineReminder,
   clearTodoDisciplineMarkersForRun,
   decideTodoDisciplineReminders,
+  doneFlipsFromSet,
   TODO_DISCIPLINE_REMINDER_LIMIT,
   type TodoDoneFlip,
 } from "./controller-decisions.js";
-import { PlanModeState } from "./state.js";
+import { nextTodoToPromoteIndex, PlanModeState } from "./state.js";
 import {
   ACT_MODE_TODO_TOOL,
   approveDemoPlan,
@@ -21,7 +22,7 @@ import {
   planModeStateEntry,
   startPlanModeSession,
 } from "./test-harness.js";
-import type { PlanRun } from "./types.js";
+import type { PlanRun, TodoStatus } from "./types.js";
 import { formatRelativeTime } from "./ui.js";
 
 // ── helpers ───────────────────────────────────────────────────
@@ -102,9 +103,14 @@ describe("todo discipline: state normalization", () => {
     state.replaceTodos([{ text: "a" }, { text: "b" }]);
     state.updateTodo(1, { status: "done" });
     expect(state.todos[0].everInProgress).toBe(true);
-    state.replaceTodos([{ text: "x" }]);
-    expect(state.todos[0].everInProgress).toBe(true); // fresh promotion sets it again
-    expect(state.todos[0].id).toBe(1);
+    // A fresh run's done item is never promoted, so the flag must not leak
+    // from the previous run's objects.
+    state.replaceTodos([{ text: "x", status: "done" }]);
+    expect(state.todos[0].everInProgress).toBeUndefined();
+    expect(state.todos[0].status).toBe("done");
+    // A fresh pending item still gets promoted on the new run.
+    state.replaceTodos([{ text: "y" }]);
+    expect(state.todos[0].everInProgress).toBe(true);
   });
 
   it("records lastTodoUpdateAt on every mutation path", () => {
@@ -117,6 +123,97 @@ describe("todo discipline: state normalization", () => {
     expect(state.activeRun?.lastTodoUpdateAt).toBeDefined();
     state.removeTodo(3);
     expect(state.activeRun?.lastTodoUpdateAt).toBeDefined();
+  });
+});
+
+// ── pure decision: doneFlipsFromSet (③, set path) ─────────────
+
+describe("todo discipline: doneFlipsFromSet", () => {
+  const oldTodos = [
+    { id: 1, text: "a", status: "in_progress" as const, everInProgress: true },
+    { id: 2, text: "b", status: "todo" as const },
+    { id: 3, text: "c", status: "done" as const },
+  ];
+
+  it("records fresh done items as flips with everInProgress=false", () => {
+    const flips = doneFlipsFromSet(oldTodos, [
+      { text: "a", status: "done" },
+      { text: "b", status: "done" },
+    ]);
+    expect(flips).toEqual([
+      { id: 1, everInProgress: true }, // predecessor was in_progress
+      { id: 2, everInProgress: false }, // predecessor never in_progress
+    ]);
+  });
+
+  it("skips items whose predecessor was already done (idempotent re-set)", () => {
+    const flips = doneFlipsFromSet(
+      [{ id: 1, text: "a", status: "done" as const }],
+      [{ text: "a", status: "done" }],
+    );
+    expect(flips).toEqual([]);
+  });
+
+  it("ignores non-done items", () => {
+    const flips = doneFlipsFromSet(oldTodos, [
+      { text: "a", status: "in_progress" },
+      { text: "b" },
+    ]);
+    expect(flips).toEqual([]);
+  });
+
+  it("carries over the predecessor's everInProgress (matches the update path)", () => {
+    const flips = doneFlipsFromSet(
+      [{ id: 1, text: "a", status: "todo" as const, everInProgress: true }],
+      [{ text: "a", status: "done" }],
+    );
+    expect(flips).toEqual([{ id: 1, everInProgress: true }]);
+  });
+
+  it("records flips for items that did not exist before", () => {
+    const flips = doneFlipsFromSet(
+      [{ id: 1, text: "a", status: "done" as const }],
+      [
+        { text: "a", status: "done" },
+        { text: "b", status: "done" },
+      ],
+    );
+    expect(flips).toEqual([{ id: 2, everInProgress: false }]);
+  });
+});
+
+// ── pure decision: nextTodoToPromoteIndex (①) ─────────────────
+
+describe("todo discipline: nextTodoToPromoteIndex", () => {
+  const todo = (id: number, status: string) => ({
+    id,
+    text: `步骤${id}`,
+    status: status as TodoStatus,
+  });
+
+  it("promotes the first pending todo item", () => {
+    expect(nextTodoToPromoteIndex([todo(1, "todo"), todo(2, "todo")])).toBe(0);
+  });
+
+  it("returns -1 when an item is already in_progress", () => {
+    expect(
+      nextTodoToPromoteIndex([
+        todo(1, "todo"),
+        todo(2, "in_progress"),
+        todo(3, "todo"),
+      ]),
+    ).toBe(-1);
+  });
+
+  it("returns -1 when any item is blocked", () => {
+    expect(nextTodoToPromoteIndex([todo(1, "blocked"), todo(2, "todo")])).toBe(
+      -1,
+    );
+  });
+
+  it("returns -1 when nothing is pending (all done or empty)", () => {
+    expect(nextTodoToPromoteIndex([todo(1, "done"), todo(2, "done")])).toBe(-1);
+    expect(nextTodoToPromoteIndex([])).toBe(-1);
   });
 });
 

--- a/extensions/plan-mode/todo-tool.ts
+++ b/extensions/plan-mode/todo-tool.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "@sinclair/typebox";
 import type { PlanModeController } from "./controller.ts";
+import { doneFlipsFromSet } from "./controller-decisions.ts";
 import type { PlanModeState } from "./state.ts";
 import { clonePlanRun, normalizeTodoStatus } from "./state.ts";
 import { symbolForStatus } from "./ui.ts";
@@ -86,30 +87,18 @@ export const registerTodoTool = (
     ],
     parameters: todoParamsSchema,
     async execute(_toolCallId, params: TodoParams, _signal, _onUpdate, ctx) {
+      let mutatedTodoList = false;
       switch (params.action) {
         case "set": {
-          // Record todo→done flips (③): replaceTodos assigns fresh ids
-          // 1..N in list order, so compare each new item against the old
-          // item with the same id. A done item whose predecessor was not
-          // done is a flip on a fresh item (everInProgress=false).
-          const oldById = new Map(
-            controller.state.todos.map((todo) => [todo.id, todo]),
-          );
           const items = params.items ?? [];
-          items.forEach((item, index) => {
-            const status = normalizeTodoStatus(item.status ?? "todo");
-            if (status !== "done") {
-              return;
-            }
-            const previous = oldById.get(index + 1);
-            if (previous?.status !== "done") {
-              controller.recordTodoDoneFlip(index + 1, false);
-            }
-          });
+          for (const flip of doneFlipsFromSet(controller.state.todos, items)) {
+            controller.recordTodoDoneFlip(flip.id, flip.everInProgress);
+          }
           controller.state.replaceTodos(
             items,
             controller.getPlanPathForNewRun(),
           );
+          mutatedTodoList = true;
           break;
         }
         case "add":
@@ -122,6 +111,7 @@ export const registerTodoTool = (
             params.notes,
             controller.getPlanPathForNewRun(),
           );
+          mutatedTodoList = true;
           break;
         case "update":
           if (params.id === undefined) {
@@ -155,22 +145,28 @@ export const registerTodoTool = (
           ) {
             return todoToolError(`Error: TODO #${params.id} not found.`);
           }
+          mutatedTodoList = true;
           break;
         case "remove":
           if (params.id === undefined) {
             return todoToolError("Error: id is required for remove.");
           }
           controller.state.removeTodo(params.id);
+          mutatedTodoList = true;
           break;
         case "clear":
           controller.state.clearTodos();
           break;
         case "list":
+          // Read-only: must not re-arm the discipline markers below.
           break;
       }
-      // Re-arm discipline reminders: any successful todo mutation means the
-      // agent is engaging with the list again.
-      controller.clearTodoReminderMarkers();
+      if (mutatedTodoList) {
+        // Re-arm discipline reminders: any successful todo mutation means
+        // the agent is engaging with the list again (read-only `list` and
+        // `clear` — which drops the run — do not).
+        controller.clearTodoReminderMarkers();
+      }
 
       controller.updateUi(ctx);
       controller.persist();

--- a/extensions/plannotator-auto/paths.ts
+++ b/extensions/plannotator-auto/paths.ts
@@ -1,10 +1,12 @@
 import path from "node:path";
-import { DEFAULT_GIT_TIMEOUT_MS, getGitCommonDir } from "../shared/git.ts";
 import {
   defaultReviewTargetKindFromAbsolutePath,
+  getRepoSlugFromGitCommonDir,
+  HTML_REVIEW_FILE_PATTERN,
   PLAN_REVIEW_FILE_PATTERN,
   REVIEW_TARGET_PLAN_DIR,
   REVIEW_TARGET_SPECS_DIR,
+  resolveHtmlReviewDirs,
   SPEC_REVIEW_FILE_PATTERN,
 } from "../shared/review-targets.ts";
 import type { ExtraReviewTargetConfig } from "./config.ts";
@@ -15,19 +17,9 @@ import type {
   ReviewTargetKind,
 } from "./plan-review/types.ts";
 
-const resolveRepoSlugFromGitCommonDir = (cwd: string): string | null => {
-  const commonDir = getGitCommonDir(cwd, DEFAULT_GIT_TIMEOUT_MS);
-  if (!commonDir) {
-    return null;
-  }
-
-  const candidate = path.basename(path.dirname(commonDir)).trim();
-  return candidate.length > 0 ? candidate : null;
-};
-
 const getDefaultReviewRoots = (cwd: string): string[] => {
   const candidates = [
-    resolveRepoSlugFromGitCommonDir(cwd),
+    getRepoSlugFromGitCommonDir(cwd),
     path.basename(cwd).trim(),
   ].filter((candidate): candidate is string => Boolean(candidate));
 
@@ -46,17 +38,6 @@ export const getDefaultPlanDirs = (cwd: string): string[] =>
 export const getDefaultSpecDirs = (cwd: string): string[] =>
   getDefaultReviewRoots(cwd).map((root) =>
     path.join(root, REVIEW_TARGET_SPECS_DIR),
-  );
-
-export const HTML_REVIEW_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}-.+\.html$/;
-
-export const getDefaultHtmlDirs = (cwd: string): string[] =>
-  Array.from(
-    new Set(
-      [resolveRepoSlugFromGitCommonDir(cwd), path.basename(cwd).trim()]
-        .filter((candidate): candidate is string => Boolean(candidate))
-        .map((candidate) => path.join(".pi", "html", candidate)),
-    ),
   );
 
 export const resolveExtraReviewTargets = (
@@ -216,13 +197,7 @@ export const getPlanFileConfig = (ctx: {
   const resolvedPlanPath = resolvePlanPath(ctx.cwd, planFile);
   const resolvedPlanPaths = resolvePlanPaths(ctx.cwd, planFiles);
   const resolvedSpecPaths = resolvePlanPaths(ctx.cwd, specFiles);
-  const resolvedHtmlPaths =
-    config.htmlDirs === null
-      ? []
-      : resolvePlanPaths(
-          ctx.cwd,
-          config.htmlDirs ?? getDefaultHtmlDirs(ctx.cwd),
-        );
+  const resolvedHtmlPaths = resolveHtmlReviewDirs(ctx.cwd, config.htmlDirs);
   const extraReviewTargets = resolveExtraReviewTargets(
     ctx.cwd,
     config.extraReviewTargets,

--- a/extensions/shared/review-targets.ts
+++ b/extensions/shared/review-targets.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { DEFAULT_GIT_TIMEOUT_MS, getGitCommonDir } from "./git.ts";
 
 export type SharedReviewTargetKind = "plan" | "spec";
 
@@ -10,6 +11,63 @@ export const REVIEW_TARGET_ISSUES_DIR = "issues";
 export const PLAN_REVIEW_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}-.+\.md$/;
 export const SPEC_REVIEW_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}-.+-design\.md$/;
 export const REVIEW_MARKDOWN_FILE_PATTERN = /^.+\.md$/;
+export const HTML_REVIEW_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}-.+\.html$/;
+
+export const getRepoSlugFromGitCommonDir = (cwd: string): string | null => {
+  const commonDir = getGitCommonDir(cwd, DEFAULT_GIT_TIMEOUT_MS);
+  if (!commonDir) {
+    return null;
+  }
+
+  const candidate = path.basename(path.dirname(commonDir)).trim();
+  return candidate.length > 0 ? candidate : null;
+};
+
+/** Default `.pi/html/<repo>/` dirs (repo slug from the git common dir, falling back to the cwd basename). */
+export const getDefaultHtmlDirs = (cwd: string): string[] =>
+  Array.from(
+    new Set(
+      [getRepoSlugFromGitCommonDir(cwd), path.basename(cwd).trim()]
+        .filter((candidate): candidate is string => Boolean(candidate))
+        .map((candidate) => path.join(".pi", "html", candidate)),
+    ),
+  );
+
+/**
+ * Resolve the HTML artifact review dirs for `cwd` as absolute paths.
+ *
+ * Single source of truth for both extensions (plannotator-auto's review
+ * queue and plan-mode's prompt guidance + plan-phase write guard), so the
+ * two can never disagree on when HTML review is enabled:
+ * - `null` → HTML review disabled ([]);
+ * - `[]` → disabled ([]);
+ * - `undefined`/non-array → defaults (`.pi/html/<repo>/`);
+ * - non-empty array → those dirs, resolved absolute against `cwd`.
+ */
+export const resolveHtmlReviewDirs = (
+  cwd: string,
+  htmlDirs: unknown,
+): string[] => {
+  if (htmlDirs === null) {
+    return [];
+  }
+  const configured = Array.isArray(htmlDirs)
+    ? htmlDirs.flatMap((entry) => {
+        if (typeof entry !== "string") {
+          return [];
+        }
+        const trimmed = entry.trim();
+        return trimmed.length > 0 ? [trimmed] : [];
+      })
+    : [];
+  const dirs =
+    configured.length > 0
+      ? configured
+      : htmlDirs === undefined
+        ? getDefaultHtmlDirs(cwd)
+        : [];
+  return Array.from(new Set(dirs.map((dir) => path.resolve(cwd, dir))));
+};
 
 const normalizeRelativePath = (relativePath: string): string =>
   relativePath.replaceAll("\\", "/").replace(/^@/, "");


### PR DESCRIPTION


- share htmlDirs resolution in shared/review-targets.ts so plan-mode and plannotator-auto agree on null/[] disable semantics (previously plan-mode treated null as defaults while plannotator-auto disabled HTML review, leaving the agent guided into unreviewed artifacts)
- record set-path done flips with the predecessor's everInProgress so the set and update paths classify the same transition alike (fixes false batch-done reminders after legitimate per-step execution)
- extract doneFlipsFromSet and nextTodoToPromoteIndex as pure decisions; split refreshActiveRunStatus into syncActiveRunStatus + normalizeTodoDiscipline with explicit mutation call sites
- cache htmlArtifactDirs at controller restore() so the plan-phase write guard no longer spawns git on every tool call; drop construction-time process.cwd()
- re-arm todo discipline markers only on list mutations (set/add/update/remove); read-only list no longer weakens suppression
- strengthen tests: discriminating replaceTodos reset assertion, unit tests for the new pure functions, htmlDirs null/[] disable regression