### PR TITLE
feat(cr-diffview): add inline nvim mode and review.nvim-style annotations

### DIFF
--- a/extensions/cr-diffview/README.md
+++ b/extensions/cr-diffview/README.md
@@ -1,15 +1,20 @@
 # cr-diffview
 
 `/cr-neovim-start` starts a human code-review flow in a dedicated terminal
-review view named `pi-cr-<repo>`, using Neovim and `codediff.nvim`. The shortcut
-`Alt+R` starts the same flow with the interactive target picker.
+review view named `pi-cr-<repo>`, using Neovim and a review.nvim-style review
+UI (`lua/pi/cr` in the user's Neovim config). The shortcut `Alt+R` starts the
+same flow with the interactive target picker.
 
 ## Requirements
 
 - A git repository
-- tmux or herdr, with Pi running inside the managed terminal session
+- **tmux or herdr, OR a plain interactive terminal** — with tmux/herdr the
+  review opens in a dedicated review view; without either, Pi suspends its TUI
+  and launches Neovim in the foreground terminal (like Ctrl+G), resuming when
+  Neovim exits
 - Neovim on `PATH` as `nvim`
-- `codediff.nvim` configured in Neovim, with the `:CodeDiff` command available
+- The `pi.cr` module available in the Neovim config (`lua/pi/cr/init.lua`),
+  auto-started via the `CR_SOCKET` environment variable or the launch entrypoint
 
 ## Usage
 
@@ -17,20 +22,29 @@ review view named `pi-cr-<repo>`, using Neovim and `codediff.nvim`. The shortcut
   - review unstaged changes (`git diff`)
   - review staged changes (`git diff --cached`)
   - review against a base branch (`branch...HEAD`)
-- `/cr-neovim-start main` skips the selector and opens `CodeDiff main...HEAD`.
+- `/cr-neovim-start main` skips the selector and opens the review for `main...HEAD`.
 - `Alt+R` opens the same interactive selector.
-- `/cr-neovim-stop` closes the active CR review view.
+- `/cr-neovim-stop` closes the active CR review view (tmux/herdr modes; the
+  inline mode is modal and ends when Neovim exits).
 
-Staged-only and unstaged-only sessions use CodeDiff's explorer visible-groups
-configuration for the launched Neovim process.
+The review UI mirrors review.nvim's interaction: a Files/Comments sidebar with
+a unified diff pane, typed comments (Fix / Note / Question with templates) on
+diff lines (`c`, `dc`), hunk/file navigation (`]c`/`[c`, `]f`/`[f`), context
+controls (`{`/`}`), stage/unstage (`Space`), and an exit menu that sends the
+comments back to Pi (`q`) or opens the real file (`e`).
 
 While a review window is open, Pi shows a `cr-diffview` widget with the active
-review target.
+review target (tmux/herdr modes).
 
-## Annotation support
+## Annotation flow
 
-The previous `pi.cr`/`diffview.nvim` launcher could exchange saved annotations
-through Pi's CR socket protocol. The current `codediff.nvim` launcher opens
-`:CodeDiff` directly, so automatic annotation import is not available unless a
-separate Neovim bridge connects to the CR socket and writes the annotation
-artifact.
+Comments are appended to an artifact JSONL file as they are saved, and sent to
+Pi over the CR socket when the review finishes (or via the artifact as a crash
+fallback in inline mode). Pi receives them as a follow-up message in
+review.nvim-style markdown with diff context, so the agent can act on them
+directly.
+
+The inline mode replicates Pi's Ctrl+G external-editor mechanism from the
+extension (`tui.stop()` → foreground spawn → `tui.start()`); see the
+`captureTui`/`runInlineReview` comments in `index.ts` for the upstream API
+follow-up.

--- a/extensions/cr-diffview/core.test.ts
+++ b/extensions/cr-diffview/core.test.ts
@@ -104,22 +104,44 @@ describe("cr-diffview socket payload core", () => {
     ).toEqual([{ file: "src/a.ts", line: 1, comment: "Please rename." }]);
   });
 
-  it("formats annotations with structural sections for Pi follow-up", () => {
+  it("formats annotations as review.nvim-style markdown for Pi follow-up", () => {
     const prompt = formatAnnotationsPrompt([
       {
         file: "src/a.ts",
         line: 7,
-        side: "right",
-        snippet: "const value = 1",
+        type: "fix",
+        snippet: " const x = 1\n+const x = 2",
         comment: "Please rename this.",
       },
     ]);
 
-    expect(prompt).toContain("## CR annotation 1");
-    expect(prompt).toContain("- File: src/a.ts");
-    expect(prompt).toContain("- Line: 7");
-    expect(prompt).toContain("- Side: right");
-    expect(prompt).toContain("- Snippet: const value = 1");
+    expect(prompt).toContain("# Code Review Comments");
+    expect(prompt).toContain("## src/a.ts");
+    expect(prompt).toContain("### [FIX] src/a.ts:7");
+    expect(prompt).toContain("```typescript");
+    expect(prompt).toContain("+const x = 2");
+    expect(prompt).toContain("```");
     expect(prompt).toContain("Please rename this.");
+  });
+
+  it("groups annotations by file and maps comment types to labels", () => {
+    const prompt = formatAnnotationsPrompt([
+      {
+        file: "a.py",
+        line: 1,
+        type: "note",
+        snippet: "x = 1",
+        comment: "note",
+      },
+      { file: "a.py", line: 3, type: "question", comment: "q?" },
+      { file: "b.go", line: 2, comment: "legacy without type" },
+    ]);
+
+    expect(prompt).toContain("### [NOTE] a.py:1");
+    expect(prompt).toContain("```python");
+    expect(prompt).toContain("### [QUESTION] a.py:3");
+    expect(prompt).toContain("### b.go:2");
+    expect(prompt.match(/## a\.py/g)).toHaveLength(1);
+    expect(prompt.indexOf("## a.py")).toBeLessThan(prompt.indexOf("## b.go"));
   });
 });

--- a/extensions/cr-diffview/core.ts
+++ b/extensions/cr-diffview/core.ts
@@ -102,6 +102,8 @@ export type CrAnnotation = {
   line: number;
   side?: string;
   snippet?: string;
+  /** review.nvim-style comment type (fix / note / question). */
+  type?: "fix" | "note" | "question";
   comment: string;
 };
 
@@ -264,6 +266,52 @@ export const parseAnnotationsJsonl = (raw: string): CrAnnotation[] => {
   }
 };
 
+const LANGUAGE_BY_EXT: Record<string, string> = {
+  ts: "typescript",
+  tsx: "typescriptreact",
+  js: "javascript",
+  jsx: "javascriptreact",
+  py: "python",
+  go: "go",
+  rs: "rust",
+  lua: "lua",
+  sh: "bash",
+  zsh: "bash",
+  json: "json",
+  yml: "yaml",
+  yaml: "yaml",
+  md: "markdown",
+  html: "html",
+  css: "css",
+  sql: "sql",
+  vue: "vue",
+  svelte: "svelte",
+  java: "java",
+  kt: "kotlin",
+  c: "c",
+  h: "c",
+  cpp: "cpp",
+  hpp: "cpp",
+  rb: "ruby",
+  php: "php",
+};
+
+const languageForFile = (file: string): string => {
+  const ext = file.match(/\.([^.\\/]+)$/)?.[1]?.toLowerCase() ?? "";
+  return LANGUAGE_BY_EXT[ext] ?? (ext || "text");
+};
+
+const TYPE_LABELS: Record<NonNullable<CrAnnotation["type"]>, string> = {
+  fix: "FIX",
+  note: "NOTE",
+  question: "QUESTION",
+};
+
+/**
+ * Format annotations as review.nvim-style markdown:
+ * `# Code Review Comments` / `## <file>` / `### [TYPE] <file>:<line>`
+ * with a diff-context code block per comment.
+ */
 export const formatAnnotationsPrompt = (
   annotations: CrAnnotation[],
 ): string => {
@@ -271,17 +319,33 @@ export const formatAnnotationsPrompt = (
     "I annotated the code review diff in Neovim.",
     "Please analyze these comments and propose or apply fixes as appropriate.",
     "",
+    "# Code Review Comments",
+    "",
   ];
 
-  annotations.forEach((annotation, index) => {
-    lines.push(`## CR annotation ${index + 1}`);
-    lines.push(`- File: ${annotation.file}`);
-    lines.push(`- Line: ${annotation.line}`);
-    if (annotation.side) lines.push(`- Side: ${annotation.side}`);
-    if (annotation.snippet) lines.push(`- Snippet: ${annotation.snippet}`);
-    lines.push("- Comment:");
-    lines.push(annotation.comment);
-    lines.push("");
+  let currentFile = "";
+  annotations.forEach((annotation) => {
+    const file = annotation.file;
+    if (file !== currentFile) {
+      currentFile = file;
+      lines.push(`## ${file}`, "");
+    }
+    const typeLabel = annotation.type
+      ? TYPE_LABELS[annotation.type]
+      : undefined;
+    const header = typeLabel
+      ? `### [${typeLabel}] ${file}:${annotation.line}`
+      : `### ${file}:${annotation.line}`;
+    lines.push(header, "");
+    if (annotation.snippet) {
+      lines.push(
+        `\`\`\`${languageForFile(file)}`,
+        annotation.snippet,
+        "```",
+        "",
+      );
+    }
+    lines.push(annotation.comment, "");
   });
 
   return lines.join("\n");

--- a/extensions/cr-diffview/index.test.ts
+++ b/extensions/cr-diffview/index.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, readdirSync, writeFileSync } from "node:fs";
 import net from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -17,12 +18,19 @@ import crDiffviewExtension, {
   buildSessionData,
 } from "./index.ts";
 
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
 beforeEach(() => {
   vi.stubEnv("TMUX", undefined);
   vi.stubEnv("HERDR_ENV", undefined);
   vi.stubEnv("HERDR_WORKSPACE_ID", undefined);
   vi.stubEnv("HERDR_TAB_ID", undefined);
   vi.stubEnv("HERDR_PANE_ID", undefined);
+  spawnMock.mockReset();
 });
 
 afterEach(() => {
@@ -324,19 +332,182 @@ describe("cr-diffview command", () => {
     );
   });
 
-  it("requires tmux or herdr before starting Neovim", async () => {
+  it("requires interactive mode when no tmux or herdr is available", async () => {
     const exec = vi
       .fn()
       .mockResolvedValueOnce({ code: 0, stdout: "/repo\n", stderr: "" });
-    const { ctx, notify } = createTestContext({ tmux: false });
+    const { ctx, notify } = createTestContext({ tmux: false, hasUI: false });
     const { startHandler } = registerCrCommands(exec);
 
     await startHandler("main", ctx);
 
     expect(notify).toHaveBeenCalledWith(
-      `/${START_COMMAND} requires tmux or herdr`,
+      `/${START_COMMAND} requires interactive mode when no tmux or herdr is available`,
       "error",
     );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  describe("inline mode (no tmux/herdr)", () => {
+    const fakeTui = {
+      stop: vi.fn(),
+      start: vi.fn(),
+      requestRender: vi.fn(),
+    };
+    let lastChild: EventEmitter;
+
+    const createInlineContext = (repoRoot: string) => {
+      const custom = vi.fn(
+        async (
+          factory: (
+            tui: unknown,
+            theme: unknown,
+            keybindings: unknown,
+            done: () => void,
+          ) => unknown,
+        ) => {
+          factory(fakeTui, {}, {}, () => {});
+        },
+      );
+      return createTestContext({ repoRoot, tmux: false, ui: { custom } });
+    };
+
+    beforeEach(() => {
+      fakeTui.stop.mockClear();
+      fakeTui.start.mockClear();
+      fakeTui.requestRender.mockClear();
+      spawnMock.mockImplementation(() => {
+        lastChild = new EventEmitter();
+        return lastChild;
+      });
+    });
+
+    const spawnEnv = (): Record<string, string> =>
+      (spawnMock.mock.calls[0][2] as { env: Record<string, string> }).env;
+
+    const expectTuiLifecycle = () => {
+      expect(fakeTui.stop).toHaveBeenCalled();
+      expect(fakeTui.start).toHaveBeenCalled();
+      expect(fakeTui.requestRender).toHaveBeenCalledWith(true);
+      // stop must happen before the foreground spawn, start after it closes
+      expect(fakeTui.stop.mock.invocationCallOrder[0]).toBeLessThan(
+        spawnMock.mock.invocationCallOrder[0],
+      );
+      expect(spawnMock.mock.invocationCallOrder[0]).toBeLessThan(
+        fakeTui.start.mock.invocationCallOrder[0],
+      );
+    };
+
+    it("opens nvim in the foreground terminal instead of a multiplexer view", async () => {
+      const repoRoot = createRepoRoot();
+      const exec = createCrExec(repoRoot);
+      const { ctx, notify, setWidget } = createInlineContext(repoRoot);
+      const { startHandler, internalEvents } = registerCrCommands(exec);
+
+      const promise = startHandler("main", ctx);
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled());
+
+      const [command, args, options] = spawnMock.mock.calls[0] as [
+        string,
+        string[],
+        { cwd: string; env: Record<string, string>; stdio: string },
+      ];
+      expect(command).toBe("nvim");
+      expect(args).toEqual([
+        "--listen",
+        expect.stringContaining("nvim.sock"),
+        "-c",
+        'lua require("pi.cr").start()',
+      ]);
+      expect(options.cwd).toBe(repoRoot);
+      expect(options.stdio).toBe("inherit");
+      expect(options.env.CR_SOCKET).toBeTruthy();
+
+      // nvim sends the finish handshake (VimLeavePre) before exiting
+      await exchangeSocketMessages(spawnEnv().CR_SOCKET, [
+        { type: "hello" },
+        { type: "finish", annotations: [] },
+      ]);
+      lastChild.emit("close", 0);
+      await promise;
+
+      expectTuiLifecycle();
+      expect(notify).toHaveBeenCalledWith("CR review finished", "info");
+      // inline mode is modal: no widget, no file watcher
+      expect(setWidget).not.toHaveBeenCalled();
+      expect(internalEvents.emit).not.toHaveBeenCalled();
+    });
+
+    it("sends CR annotations received over the socket in inline mode", async () => {
+      const repoRoot = createRepoRoot();
+      const exec = createCrExec(repoRoot);
+      const { ctx } = createInlineContext(repoRoot);
+      const { startHandler, sendUserMessage } = registerCrCommands(exec);
+
+      const promise = startHandler("main", ctx);
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled());
+
+      await exchangeSocketMessages(spawnEnv().CR_SOCKET, [
+        { type: "hello" },
+        {
+          type: "finish",
+          annotations: [
+            {
+              file: "src/a.ts",
+              line: 7,
+              type: "fix",
+              snippet: " const x = 1\n+const x = 2",
+              comment: "Please rename this.",
+            },
+          ],
+        },
+      ]);
+
+      await vi.waitFor(() => {
+        expect(sendUserMessage).toHaveBeenCalledWith(
+          expect.stringContaining("# Code Review Comments"),
+          { deliverAs: "followUp" },
+        );
+      });
+      expect(sendUserMessage).toHaveBeenCalledWith(
+        expect.stringContaining("### [FIX] src/a.ts:7"),
+        { deliverAs: "followUp" },
+      );
+
+      lastChild.emit("close", 0);
+      await promise;
+    });
+
+    it("falls back to the annotation artifact when nvim exits without a finish handshake", async () => {
+      const repoRoot = createRepoRoot();
+      const exec = createCrExec(repoRoot);
+      const { ctx, notify } = createInlineContext(repoRoot);
+      const { startHandler, sendUserMessage } = registerCrCommands(exec);
+
+      const promise = startHandler("main", ctx);
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled());
+
+      const sessionDir = join(repoRoot, ".pi", "cr-diffview");
+      const sessionId = readdirSync(sessionDir)[0];
+      writeFileSync(
+        join(sessionDir, sessionId, "annotations.jsonl"),
+        `${JSON.stringify({ file: "src/a.ts", line: 7, comment: "Crash survivor" })}\n`,
+      );
+
+      lastChild.emit("close", 1);
+      await promise;
+
+      await vi.waitFor(() => {
+        expect(sendUserMessage).toHaveBeenCalledWith(
+          expect.stringContaining("Crash survivor"),
+          { deliverAs: "followUp" },
+        );
+      });
+      expect(notify).toHaveBeenCalledWith(
+        "CR review closed (no finish handshake)",
+        "warning",
+      );
+    });
   });
 
   it("opens a direct target diff in a new tmux Neovim window", async () => {

--- a/extensions/cr-diffview/index.ts
+++ b/extensions/cr-diffview/index.ts
@@ -1,3 +1,4 @@
+import { type ChildProcess, spawn } from "node:child_process";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import net from "node:net";
 import { tmpdir } from "node:os";
@@ -15,6 +16,7 @@ import {
   type SelectItem,
   SelectList,
   Text,
+  type TUI,
 } from "@earendil-works/pi-tui";
 import {
   FILE_WATCHER_CONTROL_CHANNEL,
@@ -542,10 +544,84 @@ const closeCrSocketServer = (server: net.Server, socketPath: string): void => {
   rmSync(socketPath, { force: true });
 };
 
+/**
+ * Inline (no tmux/herdr) review transport.
+ *
+ * HACK: the extension API has no "suspend TUI and run a foreground process"
+ * primitive. We replicate pi's own Ctrl+G external-editor mechanism
+ * (`handleOpenExternalEditor`: ui.stop() -> spawn(stdio: inherit) -> ui.start())
+ * by capturing the TUI instance handed to the `ctx.ui.custom` factory and
+ * calling its public stop()/start()/requestRender() methods.
+ *
+ * Upstream follow-up: propose a formal API (e.g. `ctx.ui.runInTerminal`)
+ * on the ExtensionUIContext so this no longer depends on TUI internals.
+ */
+const captureTui = async (ctx: ExtensionContext): Promise<TUI | null> => {
+  if (!ctx.hasUI || typeof ctx.ui.custom !== "function") return null;
+  let captured: TUI | null = null;
+  await ctx.ui.custom<void>((tui, _theme, _keybindings, done) => {
+    captured = tui;
+    done(undefined);
+    return { render: () => [], invalidate: () => {} };
+  });
+  return captured;
+};
+
+const buildNvimSpawnArgs = (session: CrSession): string[] => [
+  "--listen",
+  session.socketPath,
+  "-c",
+  buildNvimEntrypoint(),
+];
+
+type InlineReviewOptions = {
+  tui: TUI;
+  session: CrSession;
+  spawnFn?: (command: string, args: string[], options: object) => ChildProcess;
+};
+
+/**
+ * Suspend the TUI and run nvim in the foreground terminal, exactly like Ctrl+G.
+ * Resolves with nvim's exit code after the TUI has been resumed.
+ */
+const runInlineReview = async ({
+  tui,
+  session,
+  spawnFn = spawn,
+}: InlineReviewOptions): Promise<number> => {
+  return new Promise<number>((resolve) => {
+    let settled = false;
+    const settle = (code: number) => {
+      if (settled) return;
+      settled = true;
+      resolve(code);
+    };
+
+    try {
+      tui.stop();
+      process.stdout.write(
+        `Opening CR review in Neovim — Pi will resume when nvim exits.\n`,
+      );
+      const child = spawnFn("nvim", buildNvimSpawnArgs(session), {
+        cwd: session.repoRoot,
+        env: { ...process.env, CR_SOCKET: session.crSocketPath },
+        stdio: "inherit",
+      });
+      child.on("error", () => settle(-1));
+      child.on("close", (code) => settle(code ?? -1));
+    } catch {
+      settle(-1);
+    }
+  }).finally(() => {
+    tui.start();
+    tui.requestRender(true);
+  });
+};
+
 const startCrSocketServer = async (
   session: CrSession,
   pi: ExtensionAPI,
-  multiplexer: CrMultiplexer,
+  multiplexer: CrMultiplexer | null,
   onFinish?: () => void,
 ): Promise<net.Server> => {
   rmSync(session.crSocketPath, { force: true });
@@ -567,15 +643,17 @@ const startCrSocketServer = async (
         }
         if (payload?.type === "finish") {
           sendAnnotationsToPi(pi, annotationsFromFinishPayload(payload));
-          if (session.originViewId) {
-            void multiplexer.focusView(session.originViewId);
+          if (multiplexer) {
+            if (session.originViewId) {
+              void multiplexer.focusView(session.originViewId);
+            }
+            if (session.reviewViewId) {
+              void multiplexer.closeReviewView({
+                reviewViewId: session.reviewViewId,
+              });
+            }
           }
           onFinish?.();
-          if (session.reviewViewId) {
-            void multiplexer.closeReviewView({
-              reviewViewId: session.reviewViewId,
-            });
-          }
           closeCrSocketServer(server, session.crSocketPath);
         }
       }
@@ -648,6 +726,43 @@ export default function crDiffviewExtension(pi: ExtensionAPI): void {
     crWatcherSessionId = null;
   };
 
+  const runInlineStart = async (
+    pi: ExtensionAPI,
+    ctx: ExtensionContext,
+    session: CrSession,
+  ): Promise<void> => {
+    let inlineFinished = false;
+    const crSocketServer = await startCrSocketServer(session, pi, null, () => {
+      inlineFinished = true;
+    });
+
+    const tui = await captureTui(ctx);
+    if (!tui) {
+      closeCrSocketServer(crSocketServer, session.crSocketPath);
+      ctx.ui.notify(`/${START_COMMAND} requires interactive mode`, "error");
+      return;
+    }
+
+    const exitCode = await runInlineReview({ tui, session });
+    // Give the VimLeavePre finish handshake a moment to land before falling back.
+    if (!inlineFinished) {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+    if (!inlineFinished) {
+      // nvim exited without a finish handshake (crash/kill): read the artifact.
+      sendArtifactAnnotationsToPi(pi, session);
+      closeCrSocketServer(crSocketServer, session.crSocketPath);
+      ctx.ui.notify("CR review closed (no finish handshake)", "warning");
+      return;
+    }
+    ctx.ui.notify(
+      exitCode === 0
+        ? "CR review finished"
+        : `CR review finished (nvim exit code ${exitCode})`,
+      "info",
+    );
+  };
+
   const startHandler = async (
     args: string,
     ctx: ExtensionContext,
@@ -660,8 +775,12 @@ export default function crDiffviewExtension(pi: ExtensionAPI): void {
 
     const env = getExtensionEnv(ctx);
     const multiplexer = createMultiplexer(pi, env);
-    if (!multiplexer) {
-      ctx.ui.notify(`/${START_COMMAND} requires tmux or herdr`, "error");
+    const inlineMode = !multiplexer;
+    if (inlineMode && !ctx.hasUI) {
+      ctx.ui.notify(
+        `/${START_COMMAND} requires interactive mode when no tmux or herdr is available`,
+        "error",
+      );
       return;
     }
 
@@ -680,8 +799,14 @@ export default function crDiffviewExtension(pi: ExtensionAPI): void {
       repoRoot,
       scope,
       reviewViewName,
-      getOriginViewId(multiplexer, env),
+      inlineMode ? "" : getOriginViewId(multiplexer, env),
     );
+
+    if (inlineMode) {
+      await runInlineStart(pi, ctx, session);
+      return;
+    }
+
     const crSocketServer = await startCrSocketServer(
       session,
       pi,


### PR DESCRIPTION


- inline mode: when no tmux/herdr is available, suspend the Pi TUI and spawn nvim in the foreground terminal (mirrors Ctrl+G) using the TUI instance captured from ctx.ui.custom; resume and re-render on exit
- crash fallback: read the annotation artifact when nvim exits without a finish handshake
- annotations: optional `type` field; follow-up messages formatted as review.nvim-style markdown with diff context and [FIX]/[NOTE]/[QUESTION]
- tests: inline transport lifecycle, socket finish, artifact fallback, and new markdown format cases
- docs: README updated for the no-multiplexer flow and pi.cr requirement